### PR TITLE
Add touch-friendly submenu toggles for stats navigation

### DIFF
--- a/stats/index.html
+++ b/stats/index.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ศูนย์วิเคราะห์ข้อมูล - ภาพรวมสถิติ</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="site-header__inner">
+      <h1 class="site-title">ศูนย์วิเคราะห์ข้อมูล</h1>
+      <nav class="site-nav" aria-label="เมนูหลัก">
+        <ul class="menu">
+          <li class="menu-item"><a href="#overview">ภาพรวม</a></li>
+          <li class="menu-item has-submenu">
+            <div class="submenu-label">
+              <a class="submenu-link" href="#reports" aria-haspopup="true" aria-expanded="false">รายงาน</a>
+              <button class="submenu-toggle" type="button" aria-expanded="false" aria-controls="reports-submenu" aria-label="เปิดหรือปิดเมนูย่อยของรายงาน">
+                <span class="submenu-toggle-icon" aria-hidden="true">▾</span>
+                <span class="visually-hidden">สลับเมนูย่อยรายงาน</span>
+              </button>
+            </div>
+            <ul class="submenu" id="reports-submenu">
+              <li><a href="#daily">รายงานรายวัน</a></li>
+              <li><a href="#weekly">รายงานรายสัปดาห์</a></li>
+              <li><a href="#monthly">รายงานรายเดือน</a></li>
+            </ul>
+          </li>
+          <li class="menu-item has-submenu">
+            <div class="submenu-label">
+              <a class="submenu-link" href="#segments" aria-haspopup="true" aria-expanded="false">กลุ่มผู้ใช้</a>
+              <button class="submenu-toggle" type="button" aria-expanded="false" aria-controls="segments-submenu" aria-label="เปิดหรือปิดเมนูย่อยของกลุ่มผู้ใช้">
+                <span class="submenu-toggle-icon" aria-hidden="true">▾</span>
+                <span class="visually-hidden">สลับเมนูย่อยกลุ่มผู้ใช้</span>
+              </button>
+            </div>
+            <ul class="submenu" id="segments-submenu">
+              <li><a href="#demographic">ตามประชากร</a></li>
+              <li><a href="#behavior">ตามพฤติกรรม</a></li>
+              <li><a href="#technology">ตามเทคโนโลยี</a></li>
+            </ul>
+          </li>
+          <li class="menu-item"><a href="#settings">ตั้งค่า</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main class="content" id="overview">
+    <section class="card">
+      <h2>ภาพรวมสถิติ</h2>
+      <p>สำรวจภาพรวมของการใช้งานแพลตฟอร์มจากข้อมูลล่าสุด พร้อมตัวชี้วัดที่สำคัญที่แสดงผลแบบเรียลไทม์สำหรับทีมของคุณ.</p>
+    </section>
+    <section class="grid" aria-labelledby="reports-heading">
+      <h2 id="reports-heading">ไฮไลต์รายงาน</h2>
+      <article class="card" id="daily">
+        <h3>รายงานรายวัน</h3>
+        <p>ติดตามจำนวนผู้ใช้งานในแต่ละวัน พร้อมเปรียบเทียบกับค่าเฉลี่ยของสัปดาห์ก่อนหน้า.</p>
+      </article>
+      <article class="card" id="weekly">
+        <h3>รายงานรายสัปดาห์</h3>
+        <p>แสดงแนวโน้มการเติบโตและยอดการมีส่วนร่วมของผู้ใช้ในช่วง 7 วันที่ผ่านมา.</p>
+      </article>
+      <article class="card" id="monthly">
+        <h3>รายงานรายเดือน</h3>
+        <p>ดูภาพรวมของผลลัพธ์ในระยะยาวเพื่อประเมินยุทธศาสตร์และการเปลี่ยนแปลงสำคัญ.</p>
+      </article>
+    </section>
+    <section class="grid" aria-labelledby="segments-heading" id="segments">
+      <h2 id="segments-heading">กลุ่มผู้ใช้ที่สำคัญ</h2>
+      <article class="card" id="demographic">
+        <h3>แบ่งตามประชากร</h3>
+        <p>ค้นหาว่ากลุ่มอายุ เพศ และพื้นที่ใดที่มีอัตราการเติบโตสูงที่สุดในปัจจุบัน.</p>
+      </article>
+      <article class="card" id="behavior">
+        <h3>แบ่งตามพฤติกรรม</h3>
+        <p>ระบุรูปแบบการใช้งานที่สร้างคุณค่ามากที่สุด และช่วงเวลาที่ผู้ใช้มีปฏิสัมพันธ์สูงสุด.</p>
+      </article>
+      <article class="card" id="technology">
+        <h3>แบ่งตามเทคโนโลยี</h3>
+        <p>ตรวจสอบประเภทอุปกรณ์และเบราว์เซอร์ที่ใช้งานสูงสุดเพื่อปรับปรุงประสบการณ์ของผู้ใช้.</p>
+      </article>
+    </section>
+  </main>
+  <footer class="site-footer" id="settings">
+    <p>© 2025 Analytics Center. ปรับแต่งการตั้งค่าการแจ้งเตือนได้ในส่วนตั้งค่าของบัญชี.</p>
+  </footer>
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/stats/script.js
+++ b/stats/script.js
@@ -1,0 +1,84 @@
+function setupSubmenuToggles() {
+  const submenuItems = Array.from(document.querySelectorAll('.has-submenu'));
+
+  if (submenuItems.length === 0) {
+    return;
+  }
+
+  const toggleSubmenu = (item, shouldOpen) => {
+    const toggleButton = item.querySelector('.submenu-toggle');
+    const mainLink = item.querySelector('.submenu-link');
+    const isOpen = typeof shouldOpen === 'boolean' ? shouldOpen : !item.classList.contains('is-open');
+
+    item.classList.toggle('is-open', isOpen);
+
+    const expandedValue = isOpen ? 'true' : 'false';
+
+    if (toggleButton) {
+      toggleButton.setAttribute('aria-expanded', expandedValue);
+    }
+
+    if (mainLink) {
+      mainLink.setAttribute('aria-expanded', expandedValue);
+    }
+  };
+
+  const closeOtherSubmenus = (current) => {
+    submenuItems.forEach((item) => {
+      if (item !== current && item.classList.contains('is-open')) {
+        toggleSubmenu(item, false);
+      }
+    });
+  };
+
+  submenuItems.forEach((item) => {
+    const toggleButton = item.querySelector('.submenu-toggle');
+    const mainLink = item.querySelector('.submenu-link');
+
+    if (!toggleButton) {
+      return;
+    }
+
+    toggleButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const willOpen = !item.classList.contains('is-open');
+      if (willOpen) {
+        closeOtherSubmenus(item);
+      }
+      toggleSubmenu(item, willOpen);
+    });
+
+    if (mainLink) {
+      mainLink.addEventListener('click', (event) => {
+        const prefersHoverless = window.matchMedia('(hover: none)').matches;
+        const isOpen = item.classList.contains('is-open');
+
+        if (prefersHoverless && !isOpen) {
+          event.preventDefault();
+          closeOtherSubmenus(item);
+          toggleSubmenu(item, true);
+        }
+      });
+    }
+
+    item.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && item.classList.contains('is-open')) {
+        toggleSubmenu(item, false);
+        if (toggleButton) {
+          toggleButton.focus();
+        }
+      }
+    });
+  });
+
+  document.addEventListener('click', (event) => {
+    submenuItems.forEach((item) => {
+      if (!item.contains(event.target) && item.classList.contains('is-open')) {
+        toggleSubmenu(item, false);
+      }
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', setupSubmenuToggles);

--- a/stats/styles.css
+++ b/stats/styles.css
@@ -1,0 +1,271 @@
+:root {
+  color-scheme: light;
+  --nav-bg: #1d2a4d;
+  --nav-bg-soft: #22315f;
+  --nav-text: #ffffff;
+  --accent: #ffd166;
+  --content-bg: #f5f7fb;
+  --card-bg: #ffffff;
+  --card-border: #dce2f5;
+  --text-main: #1f2a44;
+  --text-muted: #4a5a79;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Sarabun", "Prompt", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--content-bg);
+  color: var(--text-main);
+  line-height: 1.6;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.site-header {
+  background: var(--nav-bg);
+  color: var(--nav-text);
+  box-shadow: 0 6px 24px rgba(6, 16, 44, 0.25);
+}
+
+.site-header__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 1.25rem;
+}
+
+.site-title {
+  margin: 0 0 1rem;
+  font-size: clamp(1.5rem, 2vw + 1rem, 2.4rem);
+  font-weight: 600;
+}
+
+.site-nav {
+  width: 100%;
+}
+
+.menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.menu-item {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+}
+
+.menu-item > a,
+.submenu a {
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.menu-item > a {
+  color: var(--nav-text);
+  padding: 0.55rem 0.25rem;
+  display: inline-flex;
+  align-items: center;
+}
+
+.menu-item > a:focus-visible,
+.submenu a:focus-visible,
+.submenu-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.menu-item > a:hover {
+  color: var(--accent);
+}
+
+.has-submenu {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.submenu-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.submenu-toggle {
+  border: none;
+  background: transparent;
+  color: var(--nav-text);
+  padding: 0.2rem 0.35rem;
+  border-radius: 6px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.submenu-toggle:hover,
+.submenu-toggle:focus-visible {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.submenu-toggle-icon {
+  font-size: 0.9rem;
+  display: inline-block;
+  transition: transform 0.2s ease;
+}
+
+.has-submenu.is-open .submenu-toggle-icon {
+  transform: rotate(180deg);
+}
+
+.submenu {
+  list-style: none;
+  margin: 0;
+  padding: 0.65rem 0;
+  min-width: 200px;
+  border-radius: 10px;
+  background: #ffffff;
+  box-shadow: 0 18px 40px rgba(12, 26, 64, 0.2);
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  display: none;
+  z-index: 10;
+}
+
+.submenu li a {
+  display: block;
+  color: var(--text-main);
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+}
+
+.submenu li a:hover {
+  background: rgba(35, 62, 106, 0.1);
+}
+
+.has-submenu.is-open > .submenu {
+  display: block;
+}
+
+.content {
+  max-width: 1100px;
+  margin: 2.5rem auto;
+  padding: 0 1.5rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 16px;
+  padding: 1.75rem;
+  box-shadow: 0 20px 45px rgba(15, 30, 60, 0.12);
+  border: 1px solid var(--card-border);
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.grid h2 {
+  margin: 0;
+}
+
+.grid .card {
+  margin: 0;
+}
+
+.site-footer {
+  background: var(--nav-bg-soft);
+  color: var(--nav-text);
+  padding: 1.5rem;
+  text-align: center;
+}
+
+@media (min-width: 720px) {
+  .grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .menu {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .site-header__inner {
+    padding: 1.25rem 1rem 1rem;
+  }
+
+  .site-title {
+    margin-bottom: 0.75rem;
+  }
+
+  .menu {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .menu-item {
+    width: 100%;
+  }
+
+  .submenu-label {
+    justify-content: space-between;
+    width: 100%;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 10px;
+    padding: 0.65rem 0.85rem;
+  }
+
+  .menu-item > a {
+    padding: 0;
+  }
+
+  .submenu {
+    position: static;
+    margin-top: 0.4rem;
+    padding: 0.25rem 0;
+    border-radius: 10px;
+    box-shadow: none;
+    background: rgba(255, 255, 255, 0.14);
+    display: none;
+  }
+
+  .submenu li a {
+    color: var(--nav-text);
+  }
+
+  .has-submenu.is-open > .submenu {
+    display: block;
+  }
+}


### PR DESCRIPTION
## Summary
- add explicit toggle buttons next to Stats navigation items so touch users can open nested menus
- wire up JavaScript listeners that toggle an `is-open` class and prevent immediate navigation on first tap for touch devices
- refresh the responsive styles so `.submenu` visibility is controlled by `.is-open`, ensuring the menus display correctly on mobile screens

## Testing
- Not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d14e7a5a308331ad054f74e4e36a38