### PR TITLE
Refactor summary pages onto shared styling

### DIFF
--- a/เว็บคณิตสถิติ/assets/css/summary.css
+++ b/เว็บคณิตสถิติ/assets/css/summary.css
@@ -1,0 +1,418 @@
+:root {
+  color-scheme: dark;
+}
+
+body.summary-page {
+  padding: 28px 20px 40px;
+  background: var(--bg, #0f1117);
+  color: var(--text, #eaecef);
+  font: 16px/1.7 "Noto Sans Thai", system-ui, ui-sans-serif, -apple-system, "Segoe UI", Roboto, "Noto Sans", Arial, sans-serif;
+}
+
+body.summary-page header,
+body.summary-page main,
+body.summary-page footer {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+body.summary-page header {
+  margin-bottom: 1.6rem;
+}
+
+body.summary-page header h1 {
+  margin: 0 0 .4rem;
+  font-size: clamp(1.75rem, 3vw, 2.1rem);
+}
+
+body.summary-page header p {
+  margin: 0;
+  color: var(--muted, #9aa0a6);
+}
+
+body.summary-page .tagline {
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  font-size: .95rem;
+  color: #cfe0ff;
+  background: rgba(125, 146, 255, .12);
+  border: 1px solid #2f3542;
+  border-radius: 999px;
+  padding: .3rem .9rem;
+  margin-top: .35rem;
+}
+
+body.summary-page main {
+  display: grid;
+  gap: 1.4rem;
+}
+
+body.summary-page .summary-1page {
+  display: grid;
+  gap: 1.4rem;
+}
+
+body.summary-page .summary-1page .cols,
+body.summary-page .cols {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+body.summary-page .summary-1page .col,
+body.summary-page .col {
+  display: grid;
+  gap: 1rem;
+}
+
+body.summary-page .card {
+  background: var(--surface, #141821);
+  border: 1px solid var(--border, #242a35);
+  border-radius: 16px;
+  padding: 1.1rem 1.35rem;
+  box-shadow: var(--shadow, 0 12px 32px rgba(0, 0, 0, .32));
+}
+
+body.summary-page .card h2,
+body.summary-page .card h3 {
+  margin-top: 0;
+}
+
+body.summary-page .grid-two {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+body.summary-page .grid-three {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+body.summary-page .grid-3 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: .75rem;
+}
+
+body.summary-page .list-tight {
+  padding-left: 1.2rem;
+}
+
+body.summary-page .list-tight li + li {
+  margin-top: .35rem;
+}
+
+body.summary-page .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: .35rem;
+  font-size: .85rem;
+  color: var(--ok, #15b588);
+  background: rgba(21, 181, 136, .12);
+  border: 1px solid rgba(21, 181, 136, .4);
+  border-radius: 999px;
+  padding: .2rem .7rem;
+}
+
+body.summary-page .highlight {
+  background: rgba(21, 181, 136, .12);
+  border-left: 4px solid var(--ok, #15b588);
+  border-radius: 12px;
+  padding: .85rem 1rem;
+}
+
+body.summary-page .warn {
+  background: rgba(245, 158, 11, .14);
+  border-left: 4px solid var(--warn, #f59e0b);
+  border-radius: 12px;
+  padding: .85rem 1rem;
+}
+
+body.summary-page .ok {
+  background: rgba(21, 181, 136, .16);
+  border: 1px solid rgba(21, 181, 136, .45);
+}
+
+body.summary-page .formula-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: .6rem;
+  font-size: .95rem;
+}
+
+body.summary-page .formula-table th,
+body.summary-page .formula-table td {
+  border: 1px solid rgba(79, 140, 255, .25);
+  padding: .55rem .65rem;
+  vertical-align: top;
+}
+
+body.summary-page .formula-table th {
+  background: rgba(79, 140, 255, .18);
+  color: #d9e6ff;
+  text-align: left;
+}
+
+body.summary-page .practice {
+  padding-left: 1.2rem;
+}
+
+body.summary-page .practice li + li {
+  margin-top: .65rem;
+}
+
+body.summary-page .practice span {
+  display: block;
+  color: var(--muted, #9aa0a6);
+  font-size: .88rem;
+  margin-top: .15rem;
+}
+
+body.summary-page .checklist {
+  padding-left: 1.2rem;
+}
+
+body.summary-page .checklist li + li {
+  margin-top: .4rem;
+}
+
+body.summary-page .muted-spacer {
+  display: block;
+  margin-top: .65rem;
+}
+
+body.summary-page .table-tight {
+  margin-top: 0;
+}
+
+body.summary-page .flow {
+  counter-reset: step;
+  display: grid;
+  gap: .55rem;
+  padding-left: 0;
+}
+
+body.summary-page .flow li {
+  list-style: none;
+  padding-left: 2.3rem;
+  position: relative;
+}
+
+body.summary-page .flow li::before {
+  counter-increment: step;
+  content: counter(step);
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 50%;
+  background: rgba(79, 140, 255, .35);
+  color: #081022;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+}
+
+body.summary-page .muted {
+  color: var(--muted, #9aa0a6);
+}
+
+body.summary-page .actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .6rem;
+  margin-top: .9rem;
+}
+
+body.summary-page .pill-btn,
+body.summary-page .pill-link {
+  display: inline-flex;
+  align-items: center;
+  gap: .35rem;
+  padding: .45rem .95rem;
+  border-radius: 999px;
+  font-size: .92rem;
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid rgba(255, 255, 255, .15);
+  background: rgba(17, 22, 32, .7);
+  color: var(--text, #eaecef);
+  transition: background .2s ease, transform .2s ease;
+}
+
+body.summary-page .pill-btn:hover,
+body.summary-page .pill-btn:focus-visible,
+body.summary-page .pill-link:hover,
+body.summary-page .pill-link:focus-visible {
+  background: rgba(79, 140, 255, .28);
+  transform: translateY(-1px);
+}
+
+body.summary-page .pill-btn {
+  border-color: rgba(125, 146, 255, .35);
+}
+
+body.summary-page .pill-btn:active {
+  transform: translateY(0);
+}
+
+body.summary-page a.inline {
+  color: var(--accent, #79a7ff);
+  text-decoration: underline;
+}
+
+body.summary-page figure {
+  margin: 1.25rem 0 1rem;
+  padding: 1rem;
+  background: rgba(79, 140, 255, .08);
+  border: 1px solid rgba(79, 140, 255, .18);
+  border-radius: 16px;
+  text-align: center;
+}
+
+body.summary-page figure img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}
+
+body.summary-page figure figcaption {
+  margin-top: .65rem;
+  font-size: .9rem;
+  color: var(--muted, #9aa0a6);
+}
+
+body.summary-page footer {
+  margin-top: 2rem;
+  text-align: right;
+  color: var(--muted, #9aa0a6);
+  font-size: .9rem;
+}
+
+body.summary-page .print-footer {
+  margin-top: 2rem;
+  text-align: center;
+  color: var(--muted, #9aa0a6);
+  font-size: .85rem;
+}
+
+body.summary-page.summary-page--catalog header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+body.summary-page.summary-page--catalog .toc {
+  max-width: 920px;
+  margin: 0 auto 2.25rem;
+  background: var(--surface, #141821);
+  border: 1px solid var(--border, #242a35);
+  border-radius: 18px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: var(--shadow, 0 18px 44px rgba(0, 0, 0, .35));
+}
+
+body.summary-page.summary-page--catalog .toc h2 {
+  margin: 0 0 .85rem;
+  font-size: 1.25rem;
+  color: #d9e6ff;
+}
+
+body.summary-page.summary-page--catalog .toc-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: .6rem .9rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+body.summary-page.summary-page--catalog .toc-list a {
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+  padding: .55rem .75rem;
+  background: rgba(79, 140, 255, .12);
+  border-radius: 999px;
+  color: #9fc3ff;
+  text-decoration: none;
+  font-weight: 500;
+  transition: transform .2s ease, background .2s ease;
+}
+
+body.summary-page.summary-page--catalog .toc-list a span:first-child {
+  color: #f0f4ff;
+  font-weight: 600;
+}
+
+body.summary-page.summary-page--catalog .toc-list a span:last-child {
+  font-size: .9rem;
+  color: #c4d4f5;
+}
+
+body.summary-page.summary-page--catalog .toc-list a:hover,
+body.summary-page.summary-page--catalog .toc-list a:focus-visible {
+  background: rgba(79, 140, 255, .22);
+  transform: translateY(-2px);
+}
+
+body.summary-page.summary-page--catalog main {
+  max-width: 920px;
+  gap: 2.75rem;
+}
+
+body.summary-page.summary-page--catalog article {
+  border: 1px solid var(--border, #242a35);
+  border-radius: 18px;
+  background: #111520;
+  box-shadow: var(--shadow, 0 18px 44px rgba(0, 0, 0, .42));
+  overflow: hidden;
+}
+
+body.summary-page.summary-page--catalog article header {
+  margin: 0;
+  padding: 1.75rem 1.75rem 1.25rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(79, 140, 255, .22);
+  background: linear-gradient(180deg, rgba(79, 140, 255, .18), rgba(17, 21, 32, .9));
+}
+
+body.summary-page.summary-page--catalog article header h2 {
+  margin: 0 0 .4rem;
+  font-size: 1.65rem;
+  color: #f0f4ff;
+}
+
+body.summary-page.summary-page--catalog article header p {
+  margin: 0;
+  color: #b1bfda;
+}
+
+body.summary-page.summary-page--catalog .lesson-body {
+  padding: 1.5rem;
+}
+
+body.summary-page.summary-page--catalog .lesson-body section + section {
+  margin-top: 1.25rem;
+}
+
+body.summary-page .loading,
+body.summary-page .error {
+  text-align: center;
+  color: var(--muted, #9aa0a6);
+}
+
+@media (max-width: 720px) {
+  body.summary-page {
+    padding: 24px 16px 32px;
+  }
+
+  body.summary-page main {
+    gap: 1.1rem;
+  }
+}

--- a/เว็บคณิตสถิติ/assets/img/inference/confidence-interval.svg
+++ b/เว็บคณิตสถิติ/assets/img/inference/confidence-interval.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 240" role="img" aria-labelledby="title desc">
+  <title id="title">Confidence interval illustration</title>
+  <desc id="desc">Diagram of a bell curve with highlighted confidence interval and margin of error annotations.</desc>
+  <defs>
+    <linearGradient id="ci-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#111a2d" />
+      <stop offset="100%" stop-color="#101522" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="240" fill="url(#ci-bg)" rx="20" />
+  <path d="M60 170c60-200 300-200 360 0" fill="none" stroke="#79a7ff" stroke-width="4" />
+  <line x1="140" y1="170" x2="140" y2="95" stroke="#ffdd57" stroke-width="3" stroke-linecap="round" />
+  <line x1="340" y1="170" x2="340" y2="95" stroke="#ffdd57" stroke-width="3" stroke-linecap="round" />
+  <line x1="240" y1="170" x2="240" y2="70" stroke="#15b588" stroke-width="4" stroke-linecap="round" />
+  <path d="M140 95Q240 60 340 95" fill="rgba(125,146,255,0.2)" stroke="#7d92ff" stroke-width="2" />
+  <text x="240" y="60" text-anchor="middle" fill="#eafff7" font-family="'Noto Sans Thai', sans-serif" font-size="16">ค่าเฉลี่ยตัวอย่าง</text>
+  <text x="240" y="200" text-anchor="middle" fill="#9fc3ff" font-family="'Noto Sans Thai', sans-serif" font-size="14">ช่วงความเชื่อมั่น 95%</text>
+  <text x="140" y="185" text-anchor="middle" fill="#ffdd57" font-family="'Noto Sans Thai', sans-serif" font-size="13">Lower bound</text>
+  <text x="340" y="185" text-anchor="middle" fill="#ffdd57" font-family="'Noto Sans Thai', sans-serif" font-size="13">Upper bound</text>
+  <text x="240" y="110" text-anchor="middle" fill="#cfe0ff" font-family="'Noto Sans Thai', sans-serif" font-size="13">Margin of Error</text>
+</svg>

--- a/เว็บคณิตสถิติ/assets/img/inference/estimation-bridge.svg
+++ b/เว็บคณิตสถิติ/assets/img/inference/estimation-bridge.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 240" role="img" aria-labelledby="title desc">
+  <title id="title">Estimation bridge between population and sample</title>
+  <desc id="desc">Simple diagram showing a population distribution connected to a sample summary through an estimation bridge.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#1b2133" />
+      <stop offset="100%" stop-color="#0f141f" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="240" fill="url(#bg)" rx="20" />
+  <g fill="none" stroke="#4f8cff" stroke-width="3">
+    <path d="M80 170c50-90 270-90 320 0" stroke-linecap="round" />
+    <path d="M80 170h320" stroke-linecap="round" />
+  </g>
+  <g>
+    <circle cx="120" cy="120" r="52" fill="rgba(125,146,255,0.25)" stroke="#7d92ff" stroke-width="2" />
+    <text x="120" y="118" text-anchor="middle" fill="#f0f4ff" font-family="'Noto Sans Thai', sans-serif" font-size="16">Population</text>
+    <text x="120" y="140" text-anchor="middle" fill="#c4d4f5" font-family="'Noto Sans Thai', sans-serif" font-size="13">μ, σ², p</text>
+  </g>
+  <g>
+    <rect x="320" y="85" width="110" height="70" rx="12" fill="rgba(21,181,136,0.18)" stroke="#15b588" stroke-width="2" />
+    <text x="375" y="115" text-anchor="middle" fill="#eafff7" font-family="'Noto Sans Thai', sans-serif" font-size="16">Sample</text>
+    <text x="375" y="135" text-anchor="middle" fill="#bff2df" font-family="'Noto Sans Thai', sans-serif" font-size="13">x̄, s, p̂</text>
+  </g>
+  <g>
+    <path d="M180 120h120" stroke="#15b588" stroke-width="4" stroke-linecap="round" />
+    <path d="M240 120l-10-10m10 10l-10 10" stroke="#cfe0ff" stroke-width="3" stroke-linecap="round" />
+    <text x="240" y="105" text-anchor="middle" fill="#cfe0ff" font-family="'Noto Sans Thai', sans-serif" font-size="14">Estimator</text>
+    <text x="240" y="150" text-anchor="middle" fill="#9fc3ff" font-family="'Noto Sans Thai', sans-serif" font-size="13">สูตร + ตัวอย่าง = Estimate</text>
+  </g>
+</svg>

--- a/เว็บคณิตสถิติ/print.css
+++ b/เว็บคณิตสถิติ/print.css
@@ -34,6 +34,26 @@
     padding: 0 !important;
   }
 
+  body.summary-page {
+    padding: 0 !important;
+  }
+
+  body.summary-page header,
+  body.summary-page main,
+  body.summary-page footer,
+  body.summary-page .toc {
+    max-width: 100% !important;
+    margin: 0 0 12pt 0 !important;
+    padding: 0 !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+  }
+
+  body.summary-page .toc {
+    padding: 10pt 12pt !important;
+    border: 1px solid #bbb !important;
+  }
+
   h1, h2, h3, h4 {
     color: #000 !important;
     page-break-after: avoid;
@@ -72,6 +92,25 @@
 
   figcaption, caption, .muted {
     color: #333 !important;
+  }
+
+  body.summary-page .tagline,
+  body.summary-page .badge {
+    background: #fff !important;
+    border: 1px solid #999 !important;
+    color: #000 !important;
+  }
+
+  body.summary-page .highlight,
+  body.summary-page .warn {
+    background: #fff !important;
+    border-left-color: #666 !important;
+    color: #000 !important;
+  }
+
+  body.summary-page .loading,
+  body.summary-page .error {
+    display: none !important;
   }
 
   .note, .ok, .warn {

--- a/เว็บคณิตสถิติ/summary-lesson01.html
+++ b/เว็บคณิตสถิติ/summary-lesson01.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุป 1 หน้า – บทที่ 1 — ความรู้เบื้องต้นเกี่ยวกับสถิติ</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -20,27 +21,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body { font: 16px/1.6 system-ui,"Noto Sans Thai",sans-serif; margin: 0; padding: 20px; background: #0f1117; color: #eaecef; }
-    header h1 { margin: .2rem 0; }
-    header p { color: #9aa0a6; margin: 0 0 1rem; }
-    .summary-1page { display: block; }
-    .cols { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; }
-    .card { background: #141821; border: 1px solid #242a35; border-radius: 14px; padding: 12px; margin: 6px 0; }
-    .card h3 { margin: .2rem 0 .4rem; }
-    .muted { color: #9aa0a6; }
-    .ok { background: #0f231c; border-left: 4px solid #15b588; padding: .6rem; border-radius: 12px; }
-    .warn { background: #2a160c; border-left: 4px solid #f59e0b; padding: .6rem; border-radius: 12px; }
-    table { width: 100%; border-collapse: collapse; margin: .4rem 0; }
-    th, td { border: 1px solid #242a35; padding: .45rem; font-size: .95rem; }
-    th { background: rgba(79,140,255,.15); }
-    ul { margin: .2rem 0 .2rem 1rem; padding: 0; }
-    .grid-3 { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: .6rem; }
-    footer { margin-top: 8px; color: #9aa0a6; font-size: .9rem; }
-    @media (max-width: 920px) { .cols, .grid-3 { grid-template-columns: 1fr; } }
-  </style>
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson01",
+      "lesson": "lesson01",
+      "title": "สรุป 1 หน้า – บทที่ 1 — ความรู้เบื้องต้นเกี่ยวกับสถิติ",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
+    }
+  </script>
 </head>
-<body>
+<body class="summary-page">
   <header>
     <h1>📄 สรุป 1 หน้า – บทที่ 1 — ความรู้เบื้องต้นเกี่ยวกับสถิติ</h1>
     <p class="muted">รุ่น 1.2.0 · อัปเดต 26 กันยายน 2025 · ใช้คู่กับบทเรียนเต็มและแบบฝึกหัด JSON + Reading Toolkit</p>

--- a/เว็บคณิตสถิติ/summary-lesson02.html
+++ b/เว็บคณิตสถิติ/summary-lesson02.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุป 1 หน้า – บทที่ 2 — การนำเสนอข้อมูล</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -20,33 +21,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body{font:16px/1.6 system-ui,'Noto Sans Thai',sans-serif;margin:0;padding:24px;background:#0f1117;color:#eaecef}
-    header h1{margin:.2rem 0}
-    header p{color:#9aa0a6;margin:0 0 1rem}
-    .summary-1page{display:block}
-    .cols{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:1rem}
-    .summary-1page h3{margin:.4rem 0}
-    .card{background:#141821;border:1px solid #242a35;border-radius:12px;padding:12px;margin:10px 0}
-    .ok{background:#0f231c;border-left:4px solid #15b588;padding:.6rem;border-radius:10px}
-    .warn{background:#2a160c;border-left:4px solid #f59e0b;padding:.6rem;border-radius:10px}
-    .muted{color:#9aa0a6}
-    .actions{display:flex;gap:.6rem;flex-wrap:wrap;margin:.8rem 0}
-    .pill-btn,.pill-link{display:inline-flex;align-items:center;gap:.35rem;padding:.45rem .9rem;border-radius:999px;border:1px solid #242a35;background:#1b2130;color:#eaecef;text-decoration:none;font-size:.95rem}
-    .pill-btn{cursor:pointer}
-    .pill-btn:hover,.pill-link:hover{background:#232a3a}
-    table{width:100%;border-collapse:collapse;margin:.3rem 0}
-    th,td{border:1px solid #242a35;padding:.45rem;font-size:.95rem}
-    th{background:rgba(79,140,255,.15)}
-    .grid-3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.6rem}
-    .print-footer{margin-top:8px;color:#9aa0a6;font-size:.9rem}
-    .page-break{page-break-before:always;break-before:always;margin-top:16px}
-    @media (max-width:900px){
-      .cols,.grid-3{grid-template-columns:1fr}
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson02",
+      "lesson": "lesson02",
+      "title": "สรุป 1 หน้า – บทที่ 2 — การนำเสนอข้อมูล",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
 
   <header>
     <h1>📄 สรุป 1 หน้า – บทที่ 2 — การนำเสนอข้อมูล</h1>

--- a/เว็บคณิตสถิติ/summary-lesson03.html
+++ b/เว็บคณิตสถิติ/summary-lesson03.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุป 1 หน้า – บทที่ 3 — สถิติเชิงพรรณนา</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -20,25 +21,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body{font:16px/1.6 system-ui,'Noto Sans Thai',sans-serif;margin:0;padding:24px;background:#0f1117;color:#eaecef}
-    header h1{margin:.2rem 0}
-    header p{color:#9aa0a6;margin:0 0 1rem}
-    .summary-1page{display:block}
-    .summary-1page .col{display:inline-block;vertical-align:top;width:48%;margin:0 1% 12px 0}
-    .summary-1page h3{margin:.4rem 0}
-    .card{background:#141821;border:1px solid #242a35;border-radius:12px;padding:12px;margin:10px 0}
-    .ok{background:#0f231c;border-left:4px solid #15b588;padding:.6rem;border-radius:10px}
-    .warn{background:#2a160c;border-left:4px solid #f59e0b;padding:.6rem;border-radius:10px}
-    .muted{color:#9aa0a6}
-    .print-footer{margin-top:8px;color:#9aa0a6;font-size:.9rem}
-    .page-break{page-break-before:always;break-before:always;margin-top:16px}
-    @media (max-width:900px){
-      .summary-1page .col{display:block;width:100%}
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson03",
+      "lesson": "lesson03",
+      "title": "สรุป 1 หน้า – บทที่ 3 — สถิติเชิงพรรณนา",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
 
   <header>
     <h1>📄 สรุป 1 หน้า – บทที่ 3 — สถิติเชิงพรรณนา</h1>

--- a/เว็บคณิตสถิติ/summary-lesson04.html
+++ b/เว็บคณิตสถิติ/summary-lesson04.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุป 1 หน้า – บทที่ 4 — ความน่าจะเป็นเบื้องต้น</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -20,25 +21,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body{font:16px/1.6 system-ui,'Noto Sans Thai',sans-serif;margin:0;padding:24px;background:#0f1117;color:#eaecef}
-    header h1{margin:.2rem 0}
-    header p{color:#9aa0a6;margin:0 0 1rem}
-    .summary-1page{display:block}
-    .summary-1page .col{display:inline-block;vertical-align:top;width:48%;margin:0 1% 12px 0}
-    .summary-1page h3{margin:.4rem 0}
-    .card{background:#141821;border:1px solid #242a35;border-radius:12px;padding:12px;margin:10px 0}
-    .ok{background:#0f231c;border-left:4px solid #15b588;padding:.6rem;border-radius:10px}
-    .warn{background:#2a160c;border-left:4px solid #f59e0b;padding:.6rem;border-radius:10px}
-    .muted{color:#9aa0a6}
-    .print-footer{margin-top:8px;color:#9aa0a6;font-size:.9rem}
-    .page-break{page-break-before:always;break-before:always;margin-top:16px}
-    @media (max-width:900px){
-      .summary-1page .col{display:block;width:100%}
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson04",
+      "lesson": "lesson04",
+      "title": "สรุป 1 หน้า – บทที่ 4 — ความน่าจะเป็นเบื้องต้น",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
 
   <header>
     <h1>📄 สรุป 1 หน้า – บทที่ 4 — ความน่าจะเป็นเบื้องต้น</h1>

--- a/เว็บคณิตสถิติ/summary-lesson05.html
+++ b/เว็บคณิตสถิติ/summary-lesson05.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุป 1 หน้า – บทที่ 5 — ทฤษฎีความน่าจะเป็น (เงื่อนไข/เบย์)</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -20,25 +21,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body{font:16px/1.6 system-ui,'Noto Sans Thai',sans-serif;margin:0;padding:24px;background:#0f1117;color:#eaecef}
-    header h1{margin:.2rem 0}
-    header p{color:#9aa0a6;margin:0 0 1rem}
-    .summary-1page{display:block}
-    .summary-1page .col{display:inline-block;vertical-align:top;width:48%;margin:0 1% 12px 0}
-    .summary-1page h3{margin:.4rem 0}
-    .card{background:#141821;border:1px solid #242a35;border-radius:12px;padding:12px;margin:10px 0}
-    .ok{background:#0f231c;border-left:4px solid #15b588;padding:.6rem;border-radius:10px}
-    .warn{background:#2a160c;border-left:4px solid #f59e0b;padding:.6rem;border-radius:10px}
-    .muted{color:#9aa0a6}
-    .print-footer{margin-top:8px;color:#9aa0a6;font-size:.9rem}
-    .page-break{page-break-before:always;break-before:always;margin-top:16px}
-    @media (max-width:900px){
-      .summary-1page .col{display:block;width:100%}
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson05",
+      "lesson": "lesson05",
+      "title": "สรุป 1 หน้า – บทที่ 5 — ทฤษฎีความน่าจะเป็น (เงื่อนไข/เบย์)",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
 
   <header>
     <h1>📄 สรุป 1 หน้า – บทที่ 5 — ทฤษฎีความน่าจะเป็น (เงื่อนไข/เบย์)</h1>

--- a/เว็บคณิตสถิติ/summary-lesson06.html
+++ b/เว็บคณิตสถิติ/summary-lesson06.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุป 1 หน้า – บทที่ 6 — ตัวแปรสุ่ม (PMF/PDF/คาดหวัง/แปรปรวน)</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -20,25 +21,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body{font:16px/1.6 system-ui,'Noto Sans Thai',sans-serif;margin:0;padding:24px;background:#0f1117;color:#eaecef}
-    header h1{margin:.2rem 0}
-    header p{color:#9aa0a6;margin:0 0 1rem}
-    .summary-1page{display:block}
-    .summary-1page .col{display:inline-block;vertical-align:top;width:48%;margin:0 1% 12px 0}
-    .summary-1page h3{margin:.4rem 0}
-    .card{background:#141821;border:1px solid #242a35;border-radius:12px;padding:12px;margin:10px 0}
-    .ok{background:#0f231c;border-left:4px solid #15b588;padding:.6rem;border-radius:10px}
-    .warn{background:#2a160c;border-left:4px solid #f59e0b;padding:.6rem;border-radius:10px}
-    .muted{color:#9aa0a6}
-    .print-footer{margin-top:8px;color:#9aa0a6;font-size:.9rem}
-    .page-break{page-break-before:always;break-before:always;margin-top:16px}
-    @media (max-width:900px){
-      .summary-1page .col{display:block;width:100%}
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson06",
+      "lesson": "lesson06",
+      "title": "สรุป 1 หน้า – บทที่ 6 — ตัวแปรสุ่ม (PMF/PDF/คาดหวัง/แปรปรวน)",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
 
   <header>
     <h1>📄 สรุป 1 หน้า – บทที่ 6 — ตัวแปรสุ่ม (PMF/PDF/คาดหวัง/แปรปรวน)</h1>

--- a/เว็บคณิตสถิติ/summary-lesson07.html
+++ b/เว็บคณิตสถิติ/summary-lesson07.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุป 1 หน้า – บทที่ 7 — การแจกแจงไม่ต่อเนื่อง (Bernoulli/Binomial/Poisson/Hypergeometric)</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -20,25 +21,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body{font:16px/1.6 system-ui,'Noto Sans Thai',sans-serif;margin:0;padding:24px;background:#0f1117;color:#eaecef}
-    header h1{margin:.2rem 0}
-    header p{color:#9aa0a6;margin:0 0 1rem}
-    .summary-1page{display:block}
-    .summary-1page .col{display:inline-block;vertical-align:top;width:48%;margin:0 1% 12px 0}
-    .summary-1page h3{margin:.4rem 0}
-    .card{background:#141821;border:1px solid #242a35;border-radius:12px;padding:12px;margin:10px 0}
-    .ok{background:#0f231c;border-left:4px solid #15b588;padding:.6rem;border-radius:10px}
-    .warn{background:#2a160c;border-left:4px solid #f59e0b;padding:.6rem;border-radius:10px}
-    .muted{color:#9aa0a6}
-    .print-footer{margin-top:8px;color:#9aa0a6;font-size:.9rem}
-    .page-break{page-break-before:always;break-before:always;margin-top:16px}
-    @media (max-width:900px){
-      .summary-1page .col{display:block;width:100%}
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson07",
+      "lesson": "lesson07",
+      "title": "สรุป 1 หน้า – บทที่ 7 — การแจกแจงไม่ต่อเนื่อง (Bernoulli/Binomial/Poisson/Hypergeometric)",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
 
   <header>
     <h1>📄 สรุป 1 หน้า – บทที่ 7 — การแจกแจงไม่ต่อเนื่อง (Bernoulli/Binomial/Poisson/Hypergeometric)</h1>

--- a/เว็บคณิตสถิติ/summary-lesson08.html
+++ b/เว็บคณิตสถิติ/summary-lesson08.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุป 1 หน้า – บทที่ 8 — แจกแจงต่อเนื่อง & โค้งปกติ</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -20,25 +21,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body{font:16px/1.6 system-ui,'Noto Sans Thai',sans-serif;margin:0;padding:24px;background:#0f1117;color:#eaecef}
-    header h1{margin:.2rem 0}
-    header p{color:#9aa0a6;margin:0 0 1rem}
-    .summary-1page{display:block}
-    .summary-1page .col{display:inline-block;vertical-align:top;width:48%;margin:0 1% 12px 0}
-    .summary-1page h3{margin:.4rem 0}
-    .card{background:#141821;border:1px solid #242a35;border-radius:12px;padding:12px;margin:10px 0}
-    .ok{background:#0f231c;border-left:4px solid #15b588;padding:.6rem;border-radius:10px}
-    .warn{background:#2a160c;border-left:4px solid #f59e0b;padding:.6rem;border-radius:10px}
-    .muted{color:#9aa0a6}
-    .print-footer{margin-top:8px;color:#9aa0a6;font-size:.9rem}
-    .page-break{page-break-before:always;break-before:always;margin-top:16px}
-    @media (max-width:900px){
-      .summary-1page .col{display:block;width:100%}
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson08",
+      "lesson": "lesson08",
+      "title": "สรุป 1 หน้า – บทที่ 8 — แจกแจงต่อเนื่อง & โค้งปกติ",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
 
   <header>
     <h1>📄 สรุป 1 หน้า – บทที่ 8 — แจกแจงต่อเนื่อง & โค้งปกติ</h1>

--- a/เว็บคณิตสถิติ/summary-lesson09.html
+++ b/เว็บคณิตสถิติ/summary-lesson09.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุป 1 หน้า – บทที่ 9 — Sampling Distributions & CLT (x̄, p̂)</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -20,25 +21,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body{font:16px/1.6 system-ui,'Noto Sans Thai',sans-serif;margin:0;padding:24px;background:#0f1117;color:#eaecef}
-    header h1{margin:.2rem 0}
-    header p{color:#9aa0a6;margin:0 0 1rem}
-    .summary-1page{display:block}
-    .summary-1page .col{display:inline-block;vertical-align:top;width:48%;margin:0 1% 12px 0}
-    .summary-1page h3{margin:.4rem 0}
-    .card{background:#141821;border:1px solid #242a35;border-radius:12px;padding:12px;margin:10px 0}
-    .ok{background:#0f231c;border-left:4px solid #15b588;padding:.6rem;border-radius:10px}
-    .warn{background:#2a160c;border-left:4px solid #f59e0b;padding:.6rem;border-radius:10px}
-    .muted{color:#9aa0a6}
-    .print-footer{margin-top:8px;color:#9aa0a6;font-size:.9rem}
-    .page-break{page-break-before:always;break-before:always;margin-top:16px}
-    @media (max-width:900px){
-      .summary-1page .col{display:block;width:100%}
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson09",
+      "lesson": "lesson09",
+      "title": "สรุป 1 หน้า – บทที่ 9 — Sampling Distributions & CLT (x̄, p̂)",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
 
   <header>
     <h1>📄 สรุป 1 หน้า – บทที่ 9 — Sampling Distributions & CLT (x̄, p̂)</h1>

--- a/เว็บคณิตสถิติ/summary-lesson11-22.html
+++ b/เว็บคณิตสถิติ/summary-lesson11-22.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>รวมสรุปบทเรียน 11–22 — Estimation &amp; Inference</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -17,243 +18,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    :root {
-      color-scheme: dark;
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson11-22",
+      "lesson": "lesson11-22",
+      "title": "รวมสรุปบทเรียน 11–22 — Estimation &amp; Inference",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-    body {
-      margin: 0;
-      padding: 28px 20px 48px;
-      background: #0f1117;
-      color: #eaecef;
-      font: 16px/1.65 "Noto Sans Thai", system-ui, sans-serif;
-    }
-    header {
-      max-width: 920px;
-      margin: 0 auto 2rem;
-      text-align: center;
-    }
-    header h1 {
-      margin: 0 0 .65rem;
-      font-size: 2.15rem;
-    }
-    header p {
-      margin: 0;
-      color: #9aa0a6;
-    }
-    .toc {
-      max-width: 920px;
-      margin: 0 auto 2.25rem;
-      background: #141821;
-      border: 1px solid #242a35;
-      border-radius: 16px;
-      padding: 1.25rem 1.5rem;
-      box-shadow: 0 16px 40px rgba(0, 0, 0, .35);
-    }
-    .toc h2 {
-      margin: 0 0 .85rem;
-      font-size: 1.25rem;
-      color: #d9e6ff;
-    }
-    .toc-list {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: .6rem .9rem;
-      list-style: none;
-      padding: 0;
-      margin: 0;
-    }
-    .toc-list a {
-      display: inline-flex;
-      align-items: center;
-      gap: .5rem;
-      padding: .55rem .75rem;
-      background: rgba(79,140,255,.12);
-      border-radius: 999px;
-      color: #9fc3ff;
-      text-decoration: none;
-      font-weight: 500;
-      transition: transform .2s ease, background .2s ease;
-    }
-    .toc-list a span:first-child {
-      color: #f0f4ff;
-      font-weight: 600;
-    }
-    .toc-list a span:last-child {
-      font-size: .9rem;
-      color: #c4d4f5;
-    }
-    .toc-list a:hover {
-      background: rgba(79,140,255,.22);
-      transform: translateY(-2px);
-    }
-    main {
-      max-width: 920px;
-      margin: 0 auto;
-      display: grid;
-      gap: 2.75rem;
-    }
-    article {
-      border: 1px solid #242a35;
-      border-radius: 18px;
-      background: #111520;
-      box-shadow: 0 18px 44px rgba(0,0,0,.42);
-      overflow: hidden;
-    }
-    article header {
-      margin: 0;
-      padding: 1.75rem 1.75rem 1.25rem;
-      text-align: left;
-      border-bottom: 1px solid rgba(79,140,255,.22);
-      background: linear-gradient(180deg, rgba(79,140,255,.18), rgba(17,21,32,.9));
-    }
-    article header h2 {
-      margin: 0 0 .4rem;
-      font-size: 1.65rem;
-      color: #f0f4ff;
-    }
-    article header p {
-      margin: 0;
-      color: #b1bfda;
-    }
-    .lesson-body {
-      padding: 1.5rem;
-    }
-    .lesson-body section + section {
-      margin-top: 1.25rem;
-    }
-    .tagline {
-      display: inline-flex;
-      align-items: center;
-      gap: .45rem;
-      font-size: .95rem;
-      color: #cfe0ff;
-      background: rgba(125,146,255,.12);
-      border: 1px solid #2f3542;
-      border-radius: 999px;
-      padding: .3rem .9rem;
-      margin-top: .35rem;
-    }
-    .grid-two {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 1rem;
-    }
-    .list-tight {
-      padding-left: 1.2rem;
-    }
-    .list-tight li + li {
-      margin-top: .35rem;
-    }
-    .card {
-      background: #141821;
-      border: 1px solid #242a35;
-      border-radius: 14px;
-      padding: 1.1rem 1.35rem;
-      box-shadow: 0 10px 28px rgba(0, 0, 0, .32);
-    }
-    .card h2,
-    .card h3 {
-      margin-top: 0;
-    }
-    .formula-table {
-      width: 100%;
-      border-collapse: collapse;
-      margin-top: .6rem;
-      font-size: .95rem;
-    }
-    .formula-table th,
-    .formula-table td {
-      border: 1px solid rgba(79,140,255,.25);
-      padding: .55rem .65rem;
-      vertical-align: top;
-    }
-    .formula-table th {
-      background: rgba(79,140,255,.18);
-      color: #d9e6ff;
-      text-align: left;
-    }
-    .badge {
-      display: inline-flex;
-      align-items: center;
-      gap: .35rem;
-      font-size: .85rem;
-      color: #15b588;
-      background: rgba(21,181,136,.12);
-      border: 1px solid rgba(21,181,136,.4);
-      border-radius: 999px;
-      padding: .2rem .7rem;
-    }
-    .highlight {
-      background: rgba(21,181,136,.12);
-      border-left: 4px solid #15b588;
-      border-radius: 10px;
-      padding: .85rem 1rem;
-    }
-    .warn {
-      background: rgba(245,158,11,.14);
-      border-left: 4px solid #f59e0b;
-      border-radius: 10px;
-      padding: .85rem 1rem;
-    }
-    .practice li + li {
-      margin-top: .65rem;
-    }
-    .practice span {
-      display: block;
-      color: #9aa0a6;
-      font-size: .88rem;
-      margin-top: .15rem;
-    }
-    .checklist li + li {
-      margin-top: .4rem;
-    }
-    .muted {
-      color: #9aa0a6;
-    }
-    .lesson-body footer {
-      margin-top: 1.5rem;
-      text-align: right;
-      color: #9aa0a6;
-      font-size: .9rem;
-    }
-    .loading,
-    .error {
-      max-width: 920px;
-      margin: 0 auto;
-      color: #9aa0a6;
-      text-align: center;
-    }
-    .loading {
-      padding: 4rem 0 3rem;
-      font-size: 1.05rem;
-    }
-    .error {
-      padding: 2rem 1rem;
-      background: rgba(245,101,101,.12);
-      border: 1px solid rgba(245,101,101,.4);
-      border-radius: 14px;
-    }
-    @media (max-width: 720px) {
-      body {
-        padding: 24px 16px 40px;
-      }
-      header h1 {
-        font-size: 1.8rem;
-      }
-      .toc {
-        padding: 1.1rem 1.2rem;
-      }
-      article header {
-        padding: 1.4rem 1.2rem 1.1rem;
-      }
-      .lesson-body {
-        padding: 1.2rem 1rem 1.3rem;
-      }
-    }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page summary-page--catalog">
   <header>
     <h1>รวมสรุปบทเรียน 11–22</h1>
     <p>อ่านเนื้อหา Estimation และ Hypothesis Testing ที่ขยายใหม่ทั้งหมดในหน้าเดียว — พร้อมสูตร, แบบฝึกหัด, และสรุป 1 หน้า</p>

--- a/เว็บคณิตสถิติ/summary-lesson11.html
+++ b/เว็บคณิตสถิติ/summary-lesson11.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุปบทเรียน บทที่ 11 — รู้จักการประมาณค่า</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -17,34 +18,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body { margin: 0; padding: 28px 20px 40px; background: #0f1117; color: #eaecef; font: 16px/1.65 "Noto Sans Thai", system-ui, sans-serif; }
-    header { max-width: 880px; margin: 0 auto 1.5rem; }
-    header h1 { margin: 0 0 .35rem; font-size: 2.05rem; }
-    header p { margin: 0; color: #9aa0a6; }
-    main { max-width: 880px; margin: 0 auto; display: grid; gap: 1.25rem; }
-    .card { background: #141821; border: 1px solid #242a35; border-radius: 14px; padding: 1.1rem 1.35rem; box-shadow: 0 10px 28px rgba(0, 0, 0, .32); }
-    .card h2, .card h3 { margin-top: 0; }
-    .tagline { display: inline-flex; align-items: center; gap: .45rem; font-size: .95rem; color: #cfe0ff; background: rgba(125,146,255,.12); border: 1px solid #2f3542; border-radius: 999px; padding: .3rem .9rem; margin-top: .35rem; }
-    .grid-two { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
-    .list-tight li + li { margin-top: .35rem; }
-    .formula-table { width: 100%; border-collapse: collapse; margin-top: .6rem; font-size: .95rem; }
-    .formula-table th, .formula-table td { border: 1px solid rgba(79,140,255,.25); padding: .55rem .65rem; vertical-align: top; }
-    .formula-table th { background: rgba(79,140,255,.18); color: #d9e6ff; text-align: left; }
-    .badge { display: inline-flex; align-items: center; gap: .35rem; font-size: .85rem; color: #15b588; background: rgba(21,181,136,.12); border: 1px solid rgba(21,181,136,.4); border-radius: 999px; padding: .2rem .7rem; }
-    .highlight { background: rgba(21,181,136,.12); border-left: 4px solid #15b588; border-radius: 10px; padding: .85rem 1rem; }
-    .warn { background: rgba(245,158,11,.14); border-left: 4px solid #f59e0b; border-radius: 10px; padding: .85rem 1rem; }
-    .practice li + li { margin-top: .65rem; }
-    .practice span { display: block; color: #9aa0a6; font-size: .88rem; margin-top: .15rem; }
-    .checklist li + li { margin-top: .4rem; }
-    footer { max-width: 880px; margin: 2rem auto 0; text-align: right; color: #9aa0a6; font-size: .9rem; }
-    @media (max-width: 720px) {
-      body { padding: 24px 16px 32px; }
-      header h1 { font-size: 1.7rem; }
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson11",
+      "lesson": "lesson11",
+      "title": "สรุปบทเรียน บทที่ 11 — รู้จักการประมาณค่า",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
   <header>
     <h1>บทที่ 11 — รู้จักการประมาณค่า (Introduction to Estimation)</h1>
     <p class="tagline">Population ↔ Sample · เปลี่ยนข้อมูลตัวอย่างให้เป็นเรื่องราวของประชากร</p>
@@ -82,6 +71,10 @@
           </ul>
         </div>
       </div>
+      <figure>
+        <img src="assets/img/inference/estimation-bridge.svg" alt="แผนภาพแสดงความเชื่อมโยงระหว่างพารามิเตอร์ของประชากรกับสถิติของตัวอย่าง" loading="lazy">
+        <figcaption>เชื่อมจากประชากร → สูตรตัวประมาณ → ค่าที่คำนวณจากตัวอย่าง เพื่อเล่าเรื่องประชากรได้อย่างมั่นใจ</figcaption>
+      </figure>
     </section>
 
     <section class="card">
@@ -112,7 +105,7 @@
           </tr>
         </tbody>
       </table>
-      <p class="muted" style="margin-top:.65rem;">Estimator ที่นิยม: ค่าเฉลี่ยตัวอย่าง ($\bar X$), ส่วนเบี่ยงเบนมาตรฐานตัวอย่าง ($s$), และสัดส่วนตัวอย่าง ($\hat p$)</p>
+        <p class="muted muted-spacer">Estimator ที่นิยม: ค่าเฉลี่ยตัวอย่าง ($\bar X$), ส่วนเบี่ยงเบนมาตรฐานตัวอย่าง ($s$), และสัดส่วนตัวอย่าง ($\hat p$)</p>
     </section>
 
     <section class="card">

--- a/เว็บคณิตสถิติ/summary-lesson12.html
+++ b/เว็บคณิตสถิติ/summary-lesson12.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุปบทเรียน บทที่ 12 — หัวใจของการประมาณค่าแบบช่วง</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -17,35 +18,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body { margin: 0; padding: 28px 20px 40px; background: #0f1117; color: #eaecef; font: 16px/1.65 "Noto Sans Thai", system-ui, sans-serif; }
-    header { max-width: 880px; margin: 0 auto 1.5rem; }
-    header h1 { margin: 0 0 .35rem; font-size: 2.05rem; }
-    header p { margin: 0; color: #9aa0a6; }
-    main { max-width: 880px; margin: 0 auto; display: grid; gap: 1.25rem; }
-    .card { background: #141821; border: 1px solid #242a35; border-radius: 14px; padding: 1.1rem 1.35rem; box-shadow: 0 10px 28px rgba(0,0,0,.32); }
-    .card h2, .card h3 { margin-top: 0; }
-    .tagline { display: inline-flex; align-items: center; gap: .45rem; font-size: .95rem; color: #cfe0ff; background: rgba(125,146,255,.12); border: 1px solid #2f3542; border-radius: 999px; padding: .3rem .9rem; margin-top: .35rem; }
-    .grid-two { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
-    .list-tight li + li { margin-top: .35rem; }
-    .formula-table { width: 100%; border-collapse: collapse; margin-top: .6rem; font-size: .95rem; }
-    .formula-table th, .formula-table td { border: 1px solid rgba(125,146,255,.3); padding: .55rem .65rem; vertical-align: top; }
-    .formula-table th { background: rgba(125,146,255,.18); color: #dbe4ff; text-align: left; }
-    .flow { counter-reset: step; display: grid; gap: .55rem; }
-    .flow li { list-style: none; padding-left: 2.3rem; position: relative; }
-    .flow li::before { counter-increment: step; content: counter(step); position: absolute; left: 0; top: 0; width: 1.6rem; height: 1.6rem; border-radius: 50%; background: rgba(79,140,255,.35); color: #081022; display: grid; place-items: center; font-weight: 700; }
-    .highlight { background: rgba(21,181,136,.12); border-left: 4px solid #15b588; border-radius: 10px; padding: .85rem 1rem; }
-    .warn { background: rgba(245,158,11,.14); border-left: 4px solid #f59e0b; border-radius: 10px; padding: .85rem 1rem; }
-    .practice li + li { margin-top: .65rem; }
-    .practice span { display: block; color: #9aa0a6; font-size: .88rem; margin-top: .15rem; }
-    footer { max-width: 880px; margin: 2rem auto 0; text-align: right; color: #9aa0a6; font-size: .9rem; }
-    @media (max-width: 720px) {
-      body { padding: 24px 16px 32px; }
-      header h1 { font-size: 1.7rem; }
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson12",
+      "lesson": "lesson12",
+      "title": "สรุปบทเรียน บทที่ 12 — หัวใจของการประมาณค่าแบบช่วง",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
   <header>
     <h1>บทที่ 12 — หัวใจของการประมาณค่าแบบช่วง (Confidence Intervals)</h1>
     <p class="tagline">Estimate ± Margin of Error · คุมความไม่แน่นอนด้วยระดับความเชื่อมั่น</p>
@@ -74,6 +62,10 @@
           <p>$\text{Margin} = (\text{Critical Value})(\text{SE})$ — ลดได้ด้วยการเพิ่มจำนวนตัวอย่าง หรือคุมความแปรปรวนของข้อมูล</p>
         </div>
       </div>
+      <figure>
+        <img src="assets/img/inference/confidence-interval.svg" alt="กราฟระฆังคว่ำพร้อมช่วงความเชื่อมั่น 95% และการชี้ Margin of Error" loading="lazy">
+        <figcaption>มองภาพเดียวเห็นครบ: จุดกึ่งกลางคือค่าเฉลี่ยตัวอย่าง ขอบช่วงคือค่า Estimate ± Margin of Error</figcaption>
+      </figure>
     </section>
 
     <section class="card">

--- a/เว็บคณิตสถิติ/summary-lesson13.html
+++ b/เว็บคณิตสถิติ/summary-lesson13.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุปบทเรียน บทที่ 13 — การประมาณค่าเฉลี่ยของประชากร 1 กลุ่ม</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -17,32 +18,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body { margin: 0; padding: 28px 20px 40px; background: #0f1117; color: #eaecef; font: 16px/1.65 "Noto Sans Thai", system-ui, sans-serif; }
-    header { max-width: 880px; margin: 0 auto 1.5rem; }
-    header h1 { margin: 0 0 .35rem; font-size: 2.05rem; }
-    header p { margin: 0; color: #9aa0a6; }
-    main { max-width: 880px; margin: 0 auto; display: grid; gap: 1.25rem; }
-    .card { background: #141821; border: 1px solid #242a35; border-radius: 14px; padding: 1.1rem 1.35rem; box-shadow: 0 10px 28px rgba(0,0,0,.32); }
-    .card h2, .card h3 { margin-top: 0; }
-    .tagline { display: inline-flex; align-items: center; gap: .45rem; font-size: .95rem; color: #cfe0ff; background: rgba(125,146,255,.12); border: 1px solid #2f3542; border-radius: 999px; padding: .3rem .9rem; margin-top: .35rem; }
-    .grid-two { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
-    .list-tight li + li { margin-top: .35rem; }
-    .formula-table { width: 100%; border-collapse: collapse; margin-top: .6rem; font-size: .95rem; }
-    .formula-table th, .formula-table td { border: 1px solid rgba(79,140,255,.28); padding: .55rem .65rem; vertical-align: top; }
-    .formula-table th { background: rgba(79,140,255,.18); color: #dbe4ff; text-align: left; }
-    .highlight { background: rgba(21,181,136,.12); border-left: 4px solid #15b588; border-radius: 10px; padding: .85rem 1rem; }
-    .warn { background: rgba(245,158,11,.14); border-left: 4px solid #f59e0b; border-radius: 10px; padding: .85rem 1rem; }
-    .practice li + li { margin-top: .65rem; }
-    .practice span { display: block; color: #9aa0a6; font-size: .88rem; margin-top: .15rem; }
-    footer { max-width: 880px; margin: 2rem auto 0; text-align: right; color: #9aa0a6; font-size: .9rem; }
-    @media (max-width: 720px) {
-      body { padding: 24px 16px 32px; }
-      header h1 { font-size: 1.7rem; }
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson13",
+      "lesson": "lesson13",
+      "title": "สรุปบทเรียน บทที่ 13 — การประมาณค่าเฉลี่ยของประชากร 1 กลุ่ม",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
   <header>
     <h1>บทที่ 13 — การประมาณค่าเฉลี่ยของประชากร 1 กลุ่ม</h1>
     <p class="tagline">เลือก Z หรือ t · ใส่ใจ Standard Error · แปลผลพร้อมบริบท</p>

--- a/เว็บคณิตสถิติ/summary-lesson14.html
+++ b/เว็บคณิตสถิติ/summary-lesson14.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุปบทเรียน บทที่ 14 — การประมาณค่าสัดส่วนประชากรเดียว</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -17,32 +18,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body { margin: 0; padding: 28px 20px 40px; background: #0f1117; color: #eaecef; font: 16px/1.65 "Noto Sans Thai", system-ui, sans-serif; }
-    header { max-width: 880px; margin: 0 auto 1.5rem; }
-    header h1 { margin: 0 0 .35rem; font-size: 2.05rem; }
-    header p { margin: 0; color: #9aa0a6; }
-    main { max-width: 880px; margin: 0 auto; display: grid; gap: 1.25rem; }
-    .card { background: #141821; border: 1px solid #242a35; border-radius: 14px; padding: 1.1rem 1.35rem; box-shadow: 0 10px 28px rgba(0,0,0,.32); }
-    .card h2, .card h3 { margin-top: 0; }
-    .tagline { display: inline-flex; align-items: center; gap: .45rem; font-size: .95rem; color: #cfe0ff; background: rgba(125,146,255,.12); border: 1px solid #2f3542; border-radius: 999px; padding: .3rem .9rem; margin-top: .35rem; }
-    .grid-two { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
-    .list-tight li + li { margin-top: .35rem; }
-    .formula-table { width: 100%; border-collapse: collapse; margin-top: .6rem; font-size: .95rem; }
-    .formula-table th, .formula-table td { border: 1px solid rgba(79,140,255,.28); padding: .55rem .65rem; vertical-align: top; }
-    .formula-table th { background: rgba(79,140,255,.18); color: #dbe4ff; text-align: left; }
-    .highlight { background: rgba(21,181,136,.12); border-left: 4px solid #15b588; border-radius: 10px; padding: .85rem 1rem; }
-    .warn { background: rgba(245,158,11,.14); border-left: 4px solid #f59e0b; border-radius: 10px; padding: .85rem 1rem; }
-    .practice li + li { margin-top: .65rem; }
-    .practice span { display: block; color: #9aa0a6; font-size: .88rem; margin-top: .15rem; }
-    footer { max-width: 880px; margin: 2rem auto 0; text-align: right; color: #9aa0a6; font-size: .9rem; }
-    @media (max-width: 720px) {
-      body { padding: 24px 16px 32px; }
-      header h1 { font-size: 1.7rem; }
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson14",
+      "lesson": "lesson14",
+      "title": "สรุปบทเรียน บทที่ 14 — การประมาณค่าสัดส่วนประชากรเดียว",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
   <header>
     <h1>บทที่ 14 — การประมาณค่าสัดส่วนประชากรเดียว</h1>
     <p class="tagline">Binomial → Normal Approximation · เมื่อไรใช้ได้ · แปลผลเปอร์เซ็นต์อย่างมีบริบท</p>

--- a/เว็บคณิตสถิติ/summary-lesson15.html
+++ b/เว็บคณิตสถิติ/summary-lesson15.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุปบทเรียน บทที่ 15 — การประมาณค่าผลต่างของสองประชากร</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -17,32 +18,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body { margin: 0; padding: 28px 20px 40px; background: #0f1117; color: #eaecef; font: 16px/1.65 "Noto Sans Thai", system-ui, sans-serif; }
-    header { max-width: 880px; margin: 0 auto 1.5rem; }
-    header h1 { margin: 0 0 .35rem; font-size: 2.05rem; }
-    header p { margin: 0; color: #9aa0a6; }
-    main { max-width: 880px; margin: 0 auto; display: grid; gap: 1.25rem; }
-    .card { background: #141821; border: 1px solid #242a35; border-radius: 14px; padding: 1.1rem 1.35rem; box-shadow: 0 10px 28px rgba(0,0,0,.32); }
-    .card h2, .card h3 { margin-top: 0; }
-    .tagline { display: inline-flex; align-items: center; gap: .45rem; font-size: .95rem; color: #cfe0ff; background: rgba(125,146,255,.12); border: 1px solid #2f3542; border-radius: 999px; padding: .3rem .9rem; margin-top: .35rem; }
-    .grid-two { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
-    .list-tight li + li { margin-top: .35rem; }
-    .formula-table { width: 100%; border-collapse: collapse; margin-top: .6rem; font-size: .95rem; }
-    .formula-table th, .formula-table td { border: 1px solid rgba(79,140,255,.28); padding: .55rem .65rem; vertical-align: top; }
-    .formula-table th { background: rgba(79,140,255,.18); color: #dbe4ff; text-align: left; }
-    .highlight { background: rgba(21,181,136,.12); border-left: 4px solid #15b588; border-radius: 10px; padding: .85rem 1rem; }
-    .warn { background: rgba(245,158,11,.14); border-left: 4px solid #f59e0b; border-radius: 10px; padding: .85rem 1rem; }
-    .practice li + li { margin-top: .65rem; }
-    .practice span { display: block; color: #9aa0a6; font-size: .88rem; margin-top: .15rem; }
-    footer { max-width: 880px; margin: 2rem auto 0; text-align: right; color: #9aa0a6; font-size: .9rem; }
-    @media (max-width: 720px) {
-      body { padding: 24px 16px 32px; }
-      header h1 { font-size: 1.7rem; }
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson15",
+      "lesson": "lesson15",
+      "title": "สรุปบทเรียน บทที่ 15 — การประมาณค่าผลต่างของสองประชากร",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
   <header>
     <h1>บทที่ 15 — การประมาณค่าผลต่างของสองประชากร</h1>
     <p class="tagline">เปรียบเทียบค่าเฉลี่ย · เปรียบเทียบสัดส่วน · ดูว่าศูนย์อยู่ในช่วงหรือไม่</p>

--- a/เว็บคณิตสถิติ/summary-lesson16.html
+++ b/เว็บคณิตสถิติ/summary-lesson16.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุปบทเรียน บทที่ 16 — การคำนวณขนาดตัวอย่าง</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -17,32 +18,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body { margin: 0; padding: 28px 20px 40px; background: #0f1117; color: #eaecef; font: 16px/1.65 "Noto Sans Thai", system-ui, sans-serif; }
-    header { max-width: 880px; margin: 0 auto 1.5rem; }
-    header h1 { margin: 0 0 .35rem; font-size: 2.05rem; }
-    header p { margin: 0; color: #9aa0a6; }
-    main { max-width: 880px; margin: 0 auto; display: grid; gap: 1.25rem; }
-    .card { background: #141821; border: 1px solid #242a35; border-radius: 14px; padding: 1.1rem 1.35rem; box-shadow: 0 10px 28px rgba(0,0,0,.32); }
-    .card h2, .card h3 { margin-top: 0; }
-    .tagline { display: inline-flex; align-items: center; gap: .45rem; font-size: .95rem; color: #cfe0ff; background: rgba(125,146,255,.12); border: 1px solid #2f3542; border-radius: 999px; padding: .3rem .9rem; margin-top: .35rem; }
-    .grid-two { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
-    .list-tight li + li { margin-top: .35rem; }
-    .formula-table { width: 100%; border-collapse: collapse; margin-top: .6rem; font-size: .95rem; }
-    .formula-table th, .formula-table td { border: 1px solid rgba(79,140,255,.28); padding: .55rem .65rem; vertical-align: top; }
-    .formula-table th { background: rgba(79,140,255,.18); color: #dbe4ff; text-align: left; }
-    .highlight { background: rgba(21,181,136,.12); border-left: 4px solid #15b588; border-radius: 10px; padding: .85rem 1rem; }
-    .warn { background: rgba(245,158,11,.14); border-left: 4px solid #f59e0b; border-radius: 10px; padding: .85rem 1rem; }
-    .practice li + li { margin-top: .65rem; }
-    .practice span { display: block; color: #9aa0a6; font-size: .88rem; margin-top: .15rem; }
-    footer { max-width: 880px; margin: 2rem auto 0; text-align: right; color: #9aa0a6; font-size: .9rem; }
-    @media (max-width: 720px) {
-      body { padding: 24px 16px 32px; }
-      header h1 { font-size: 1.7rem; }
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson16",
+      "lesson": "lesson16",
+      "title": "สรุปบทเรียน บทที่ 16 — การคำนวณขนาดตัวอย่าง",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
   <header>
     <h1>บทที่ 16 — การคำนวณขนาดตัวอย่าง</h1>
     <p class="tagline">กำหนด Margin of Error · เลือกระดับความเชื่อมั่น · วางแผนงบประมาณการเก็บข้อมูล</p>

--- a/เว็บคณิตสถิติ/summary-lesson17.html
+++ b/เว็บคณิตสถิติ/summary-lesson17.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุปบทเรียน บทที่ 17 — พื้นฐานการทดสอบสมมติฐาน</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -17,32 +18,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body { margin: 0; padding: 28px 20px 40px; background: #0f1117; color: #eaecef; font: 16px/1.65 "Noto Sans Thai", system-ui, sans-serif; }
-    header { max-width: 880px; margin: 0 auto 1.5rem; }
-    header h1 { margin: 0 0 .35rem; font-size: 2.05rem; }
-    header p { margin: 0; color: #9aa0a6; }
-    main { max-width: 880px; margin: 0 auto; display: grid; gap: 1.25rem; }
-    .card { background: #141821; border: 1px solid #242a35; border-radius: 14px; padding: 1.1rem 1.35rem; box-shadow: 0 10px 28px rgba(0,0,0,.32); }
-    .card h2, .card h3 { margin-top: 0; }
-    .tagline { display: inline-flex; align-items: center; gap: .45rem; font-size: .95rem; color: #cfe0ff; background: rgba(125,146,255,.12); border: 1px solid #2f3542; border-radius: 999px; padding: .3rem .9rem; margin-top: .35rem; }
-    .grid-two { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
-    .list-tight li + li { margin-top: .35rem; }
-    .flow { counter-reset: step; display: grid; gap: .55rem; }
-    .flow li { list-style: none; padding-left: 2.3rem; position: relative; }
-    .flow li::before { counter-increment: step; content: counter(step); position: absolute; left: 0; top: 0; width: 1.6rem; height: 1.6rem; border-radius: 50%; background: rgba(79,140,255,.35); color: #081022; display: grid; place-items: center; font-weight: 700; }
-    .highlight { background: rgba(21,181,136,.12); border-left: 4px solid #15b588; border-radius: 10px; padding: .85rem 1rem; }
-    .warn { background: rgba(245,158,11,.14); border-left: 4px solid #f59e0b; border-radius: 10px; padding: .85rem 1rem; }
-    .practice li + li { margin-top: .65rem; }
-    .practice span { display: block; color: #9aa0a6; font-size: .88rem; margin-top: .15rem; }
-    footer { max-width: 880px; margin: 2rem auto 0; text-align: right; color: #9aa0a6; font-size: .9rem; }
-    @media (max-width: 720px) {
-      body { padding: 24px 16px 32px; }
-      header h1 { font-size: 1.7rem; }
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson17",
+      "lesson": "lesson17",
+      "title": "สรุปบทเรียน บทที่ 17 — พื้นฐานการทดสอบสมมติฐาน",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
   <header>
     <h1>บทที่ 17 — พื้นฐานการทดสอบสมมติฐาน</h1>
     <p class="tagline">H₀ vs H₁ · ระดับนัยสำคัญ · ข้อผิดพลาดสองประเภท</p>
@@ -87,7 +78,7 @@
 
     <section class="card">
       <h2>📋 ตารางข้อผิดพลาด</h2>
-      <table class="formula-table" style="margin-top:0;">
+      <table class="formula-table table-tight">
         <thead>
           <tr>
             <th>การตัดสินใจ</th>
@@ -108,7 +99,7 @@
           </tr>
         </tbody>
       </table>
-      <p class="muted" style="margin-top:.65rem;">เราคุม $\alpha$ เป็นหลัก ส่วน $\beta$ และ Power ขึ้นกับขนาดตัวอย่างและขนาดผลที่แท้จริง</p>
+      <p class="muted muted-spacer">เราคุม $\alpha$ เป็นหลัก ส่วน $\beta$ และ Power ขึ้นกับขนาดตัวอย่างและขนาดผลที่แท้จริง</p>
     </section>
 
     <section class="card">

--- a/เว็บคณิตสถิติ/summary-lesson18.html
+++ b/เว็บคณิตสถิติ/summary-lesson18.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุปบทเรียน บทที่ 18 — ประเภทของการทดสอบตามทิศทาง</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -17,29 +18,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body { margin: 0; padding: 28px 20px 40px; background: #0f1117; color: #eaecef; font: 16px/1.65 "Noto Sans Thai", system-ui, sans-serif; }
-    header { max-width: 880px; margin: 0 auto 1.5rem; }
-    header h1 { margin: 0 0 .35rem; font-size: 2.05rem; }
-    header p { margin: 0; color: #9aa0a6; }
-    main { max-width: 880px; margin: 0 auto; display: grid; gap: 1.25rem; }
-    .card { background: #141821; border: 1px solid #242a35; border-radius: 14px; padding: 1.1rem 1.35rem; box-shadow: 0 10px 28px rgba(0,0,0,.32); }
-    .card h2, .card h3 { margin-top: 0; }
-    .tagline { display: inline-flex; align-items: center; gap: .45rem; font-size: .95rem; color: #cfe0ff; background: rgba(125,146,255,.12); border: 1px solid #2f3542; border-radius: 999px; padding: .3rem .9rem; margin-top: .35rem; }
-    .grid-three { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; }
-    .list-tight li + li { margin-top: .35rem; }
-    .highlight { background: rgba(21,181,136,.12); border-left: 4px solid #15b588; border-radius: 10px; padding: .85rem 1rem; }
-    .warn { background: rgba(245,158,11,.14); border-left: 4px solid #f59e0b; border-radius: 10px; padding: .85rem 1rem; }
-    .practice li + li { margin-top: .65rem; }
-    .practice span { display: block; color: #9aa0a6; font-size: .88rem; margin-top: .15rem; }
-    footer { max-width: 880px; margin: 2rem auto 0; text-align: right; color: #9aa0a6; font-size: .9rem; }
-    @media (max-width: 720px) {
-      body { padding: 24px 16px 32px; }
-      header h1 { font-size: 1.7rem; }
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson18",
+      "lesson": "lesson18",
+      "title": "สรุปบทเรียน บทที่ 18 — ประเภทของการทดสอบตามทิศทาง",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
   <header>
     <h1>บทที่ 18 — ประเภทของการทดสอบตามทิศทาง</h1>
     <p class="tagline">Two-tailed · Left-tailed · Right-tailed · เลือกให้ตรงกับสมมติฐาน</p>

--- a/เว็บคณิตสถิติ/summary-lesson19.html
+++ b/เว็บคณิตสถิติ/summary-lesson19.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุปบทเรียน บทที่ 19 — การทดสอบค่าเฉลี่ย 1 กลุ่ม</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -17,32 +18,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body { margin: 0; padding: 28px 20px 40px; background: #0f1117; color: #eaecef; font: 16px/1.65 "Noto Sans Thai", system-ui, sans-serif; }
-    header { max-width: 880px; margin: 0 auto 1.5rem; }
-    header h1 { margin: 0 0 .35rem; font-size: 2.05rem; }
-    header p { margin: 0; color: #9aa0a6; }
-    main { max-width: 880px; margin: 0 auto; display: grid; gap: 1.25rem; }
-    .card { background: #141821; border: 1px solid #242a35; border-radius: 14px; padding: 1.1rem 1.35rem; box-shadow: 0 10px 28px rgba(0,0,0,.32); }
-    .card h2, .card h3 { margin-top: 0; }
-    .tagline { display: inline-flex; align-items: center; gap: .45rem; font-size: .95rem; color: #cfe0ff; background: rgba(125,146,255,.12); border: 1px solid #2f3542; border-radius: 999px; padding: .3rem .9rem; margin-top: .35rem; }
-    .grid-two { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
-    .list-tight li + li { margin-top: .35rem; }
-    .formula-table { width: 100%; border-collapse: collapse; margin-top: .6rem; font-size: .95rem; }
-    .formula-table th, .formula-table td { border: 1px solid rgba(79,140,255,.28); padding: .55rem .65rem; vertical-align: top; }
-    .formula-table th { background: rgba(79,140,255,.18); color: #dbe4ff; text-align: left; }
-    .highlight { background: rgba(21,181,136,.12); border-left: 4px solid #15b588; border-radius: 10px; padding: .85rem 1rem; }
-    .warn { background: rgba(245,158,11,.14); border-left: 4px solid #f59e0b; border-radius: 10px; padding: .85rem 1rem; }
-    .practice li + li { margin-top: .65rem; }
-    .practice span { display: block; color: #9aa0a6; font-size: .88rem; margin-top: .15rem; }
-    footer { max-width: 880px; margin: 2rem auto 0; text-align: right; color: #9aa0a6; font-size: .9rem; }
-    @media (max-width: 720px) {
-      body { padding: 24px 16px 32px; }
-      header h1 { font-size: 1.7rem; }
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson19",
+      "lesson": "lesson19",
+      "title": "สรุปบทเรียน บทที่ 19 — การทดสอบค่าเฉลี่ย 1 กลุ่ม",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
   <header>
     <h1>บทที่ 19 — การทดสอบค่าเฉลี่ย 1 กลุ่ม</h1>
     <p class="tagline">Z-test หรือ t-test · ตั้ง H₀/H₁ · ใช้ P-value หรือ Critical Value</p>

--- a/เว็บคณิตสถิติ/summary-lesson20.html
+++ b/เว็บคณิตสถิติ/summary-lesson20.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุปบทเรียน บทที่ 20 — การทดสอบสัดส่วน 1 กลุ่ม</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -17,29 +18,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body { margin: 0; padding: 28px 20px 40px; background: #0f1117; color: #eaecef; font: 16px/1.65 "Noto Sans Thai", system-ui, sans-serif; }
-    header { max-width: 880px; margin: 0 auto 1.5rem; }
-    header h1 { margin: 0 0 .35rem; font-size: 2.05rem; }
-    header p { margin: 0; color: #9aa0a6; }
-    main { max-width: 880px; margin: 0 auto; display: grid; gap: 1.25rem; }
-    .card { background: #141821; border: 1px solid #242a35; border-radius: 14px; padding: 1.1rem 1.35rem; box-shadow: 0 10px 28px rgba(0,0,0,.32); }
-    .card h2, .card h3 { margin-top: 0; }
-    .tagline { display: inline-flex; align-items: center; gap: .45rem; font-size: .95rem; color: #cfe0ff; background: rgba(125,146,255,.12); border: 1px solid #2f3542; border-radius: 999px; padding: .3rem .9rem; margin-top: .35rem; }
-    .grid-two { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
-    .list-tight li + li { margin-top: .35rem; }
-    .highlight { background: rgba(21,181,136,.12); border-left: 4px solid #15b588; border-radius: 10px; padding: .85rem 1rem; }
-    .warn { background: rgba(245,158,11,.14); border-left: 4px solid #f59e0b; border-radius: 10px; padding: .85rem 1rem; }
-    .practice li + li { margin-top: .65rem; }
-    .practice span { display: block; color: #9aa0a6; font-size: .88rem; margin-top: .15rem; }
-    footer { max-width: 880px; margin: 2rem auto 0; text-align: right; color: #9aa0a6; font-size: .9rem; }
-    @media (max-width: 720px) {
-      body { padding: 24px 16px 32px; }
-      header h1 { font-size: 1.7rem; }
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson20",
+      "lesson": "lesson20",
+      "title": "สรุปบทเรียน บทที่ 20 — การทดสอบสัดส่วน 1 กลุ่ม",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
   <header>
     <h1>บทที่ 20 — การทดสอบสัดส่วน 1 กลุ่ม</h1>
     <p class="tagline">Z-test for p · ตรวจเงื่อนไข np₀ · ตีความเปอร์เซ็นต์</p>

--- a/เว็บคณิตสถิติ/summary-lesson21.html
+++ b/เว็บคณิตสถิติ/summary-lesson21.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุปบทเรียน บทที่ 21 — การทดสอบผลต่างสองประชากร</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -17,32 +18,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body { margin: 0; padding: 28px 20px 40px; background: #0f1117; color: #eaecef; font: 16px/1.65 "Noto Sans Thai", system-ui, sans-serif; }
-    header { max-width: 880px; margin: 0 auto 1.5rem; }
-    header h1 { margin: 0 0 .35rem; font-size: 2.05rem; }
-    header p { margin: 0; color: #9aa0a6; }
-    main { max-width: 880px; margin: 0 auto; display: grid; gap: 1.25rem; }
-    .card { background: #141821; border: 1px solid #242a35; border-radius: 14px; padding: 1.1rem 1.35rem; box-shadow: 0 10px 28px rgba(0,0,0,.32); }
-    .card h2, .card h3 { margin-top: 0; }
-    .tagline { display: inline-flex; align-items: center; gap: .45rem; font-size: .95rem; color: #cfe0ff; background: rgba(125,146,255,.12); border: 1px solid #2f3542; border-radius: 999px; padding: .3rem .9rem; margin-top: .35rem; }
-    .grid-two { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
-    .list-tight li + li { margin-top: .35rem; }
-    .formula-table { width: 100%; border-collapse: collapse; margin-top: .6rem; font-size: .95rem; }
-    .formula-table th, .formula-table td { border: 1px solid rgba(79,140,255,.28); padding: .55rem .65rem; vertical-align: top; }
-    .formula-table th { background: rgba(79,140,255,.18); color: #dbe4ff; text-align: left; }
-    .highlight { background: rgba(21,181,136,.12); border-left: 4px solid #15b588; border-radius: 10px; padding: .85rem 1rem; }
-    .warn { background: rgba(245,158,11,.14); border-left: 4px solid #f59e0b; border-radius: 10px; padding: .85rem 1rem; }
-    .practice li + li { margin-top: .65rem; }
-    .practice span { display: block; color: #9aa0a6; font-size: .88rem; margin-top: .15rem; }
-    footer { max-width: 880px; margin: 2rem auto 0; text-align: right; color: #9aa0a6; font-size: .9rem; }
-    @media (max-width: 720px) {
-      body { padding: 24px 16px 32px; }
-      header h1 { font-size: 1.7rem; }
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson21",
+      "lesson": "lesson21",
+      "title": "สรุปบทเรียน บทที่ 21 — การทดสอบผลต่างสองประชากร",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
   <header>
     <h1>บทที่ 21 — การทดสอบผลต่างสองประชากร</h1>
     <p class="tagline">Two-sample t-test · Two-proportion z-test · เลือกสูตรให้ตรงบริบท</p>

--- a/เว็บคณิตสถิติ/summary-lesson22.html
+++ b/เว็บคณิตสถิติ/summary-lesson22.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>สรุปบทเรียน บทที่ 22 — การทดสอบความแปรปรวน</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/summary.css">
   <link rel="stylesheet" href="print.css" media="print">
   <script>
     window.MathJax = {
@@ -17,29 +18,22 @@
   </script>
   <script defer src="assets/js/reading-tools.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="mathjax-script" async></script>
-  <style>
-    body { margin: 0; padding: 28px 20px 40px; background: #0f1117; color: #eaecef; font: 16px/1.65 "Noto Sans Thai", system-ui, sans-serif; }
-    header { max-width: 880px; margin: 0 auto 1.5rem; }
-    header h1 { margin: 0 0 .35rem; font-size: 2.05rem; }
-    header p { margin: 0; color: #9aa0a6; }
-    main { max-width: 880px; margin: 0 auto; display: grid; gap: 1.25rem; }
-    .card { background: #141821; border: 1px solid #242a35; border-radius: 14px; padding: 1.1rem 1.35rem; box-shadow: 0 10px 28px rgba(0,0,0,.32); }
-    .card h2, .card h3 { margin-top: 0; }
-    .tagline { display: inline-flex; align-items: center; gap: .45rem; font-size: .95rem; color: #cfe0ff; background: rgba(125,146,255,.12); border: 1px solid #2f3542; border-radius: 999px; padding: .3rem .9rem; margin-top: .35rem; }
-    .grid-two { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
-    .list-tight li + li { margin-top: .35rem; }
-    .highlight { background: rgba(21,181,136,.12); border-left: 4px solid #15b588; border-radius: 10px; padding: .85rem 1rem; }
-    .warn { background: rgba(245,158,11,.14); border-left: 4px solid #f59e0b; border-radius: 10px; padding: .85rem 1rem; }
-    .practice li + li { margin-top: .65rem; }
-    .practice span { display: block; color: #9aa0a6; font-size: .88rem; margin-top: .15rem; }
-    footer { max-width: 880px; margin: 2rem auto 0; text-align: right; color: #9aa0a6; font-size: .9rem; }
-    @media (max-width: 720px) {
-      body { padding: 24px 16px 32px; }
-      header h1 { font-size: 1.7rem; }
+  <script type="application/json" id="summary-meta">
+    {
+      "id": "summary-lesson22",
+      "lesson": "lesson22",
+      "title": "สรุปบทเรียน บทที่ 22 — การทดสอบความแปรปรวน",
+      "version": "1.0.0",
+      "updated_at": "2025-01-15",
+      "depends_on": [
+        "assets/css/summary.css",
+        "style.css",
+        "assets/js/reading-tools.js"
+      ]
     }
-  </style>
+  </script>
 </head>
-<body>
+<body class="summary-page">
   <header>
     <h1>บทที่ 22 — การทดสอบความแปรปรวน</h1>
     <p class="tagline">Chi-square test · F-test · ตรวจความเป็นปกติและอิสระของข้อมูล</p>


### PR DESCRIPTION
## Summary
- Replace per-file inline styling for lesson summary pages with a shared `assets/css/summary.css` theme and JSON metadata hooks.
- Add reusable utility classes, responsive layout tweaks, and refreshed print rules so summaries 01–22 share consistent UX online and in exported PDFs.
- Introduce inference diagrams for lessons 11 and 12 to support visual learning without breaking the existing MathJax-driven content.

## Testing
- Not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68d617e1767883319ebe7a605ca95baa