### PR TITLE
Add confidence interval and hypothesis testing lesson modules

### DIFF
--- a/prob & Stats/content/02-descriptive.html
+++ b/prob & Stats/content/02-descriptive.html
@@ -2,13 +2,485 @@
 <html lang="th">
 <head>
   <meta charset="utf-8" />
-  <title>บทที่ 2: ข้อมูลและการสรุป</title>
+  <title>บทที่ 2: หลักการนับเบื้องต้น</title>
   <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body.page {
+      background: radial-gradient(circle at top, rgba(255,255,255,0.9), rgba(240,240,255,0.95));
+      min-height: 100vh;
+    }
+    header.hero {
+      padding: 2.5rem 1rem 1.5rem;
+      background: linear-gradient(120deg, #512da8, #9575cd);
+      color: #fff;
+      border-radius: 24px;
+      box-shadow: 0 20px 40px rgba(81,45,168,0.25);
+      margin-bottom: 2rem;
+      position: relative;
+      overflow: hidden;
+    }
+    header.hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 30% 20%, rgba(255,255,255,0.35), transparent 65%),
+                  radial-gradient(circle at 80% 0%, rgba(255,255,255,0.25), transparent 55%);
+      pointer-events: none;
+    }
+    header.hero h1 {
+      font-size: clamp(2.4rem, 3vw + 1rem, 3.4rem);
+      margin-bottom: 0.4rem;
+    }
+    header.hero p {
+      font-size: 1.1rem;
+      max-width: 60ch;
+    }
+    section.card {
+      background: rgba(255,255,255,0.85);
+      border-radius: 20px;
+      padding: 2rem clamp(1rem, 5vw, 3rem);
+      margin-bottom: 2rem;
+      box-shadow: 0 12px 32px rgba(33, 33, 52, 0.1);
+      backdrop-filter: blur(6px);
+    }
+    .columns {
+      display: grid;
+      gap: 1.5rem;
+    }
+    @media (min-width: 880px) {
+      .columns.two {
+        grid-template-columns: repeat(2, minmax(0,1fr));
+      }
+      .columns.three {
+        grid-template-columns: repeat(3, minmax(0,1fr));
+      }
+    }
+    h2 {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 1.8rem;
+    }
+    h2 span.badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: #ede7f6;
+      color: #4527a0;
+      border-radius: 999px;
+      padding: 0.1rem 0.9rem;
+      font-size: 1rem;
+      font-weight: 600;
+    }
+    .highlight {
+      padding: 1.2rem 1.4rem;
+      border-left: 6px solid #7e57c2;
+      background: rgba(126, 87, 194, 0.08);
+      border-radius: 12px;
+      margin-top: 1rem;
+    }
+    details.lesson-toggle {
+      border: 1px solid rgba(81,45,168,0.2);
+      border-radius: 14px;
+      padding: 1rem 1.4rem;
+      background: rgba(81,45,168,0.05);
+      box-shadow: inset 0 0 0 1px rgba(255,255,255,0.3);
+    }
+    details.lesson-toggle summary {
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .definition-card {
+      border-radius: 16px;
+      background: linear-gradient(160deg, rgba(197, 202, 233, 0.45), rgba(232, 234, 246, 0.6));
+      padding: 1.4rem;
+      display: grid;
+      gap: 0.6rem;
+      border: 1px solid rgba(82, 82, 122, 0.12);
+    }
+    .definition-card strong {
+      font-size: 1.05rem;
+    }
+    .code-box {
+      background: #1e1e2f;
+      color: #f9f5ff;
+      padding: 1.2rem 1.4rem;
+      border-radius: 12px;
+      font-family: "Fira Code", "SFMono-Regular", "Consolas", monospace;
+      font-size: 0.95rem;
+      line-height: 1.5;
+      overflow-x: auto;
+    }
+    .table-wrapper {
+      overflow-x: auto;
+      border-radius: 14px;
+      border: 1px solid rgba(81,45,168,0.15);
+      background: rgba(255,255,255,0.92);
+    }
+    table.styled {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    table.styled th,
+    table.styled td {
+      padding: 0.9rem 1.2rem;
+      text-align: left;
+    }
+    table.styled thead {
+      background: rgba(81,45,168,0.12);
+      color: #311b92;
+    }
+    table.styled tbody tr:nth-child(even) {
+      background: rgba(81,45,168,0.04);
+    }
+    .calculator {
+      display: grid;
+      gap: 1rem;
+      margin-top: 1rem;
+    }
+    .calculator label {
+      font-weight: 600;
+    }
+    .calculator input {
+      border-radius: 12px;
+      border: 1px solid rgba(81,45,168,0.3);
+      padding: 0.6rem 0.9rem;
+      font-size: 1rem;
+    }
+    .calculator button {
+      border: none;
+      border-radius: 999px;
+      padding: 0.7rem 1.5rem;
+      background: linear-gradient(120deg, #5e35b1, #7e57c2);
+      color: #fff;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .calculator button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 22px rgba(94,53,177,0.25);
+    }
+    .result-card {
+      margin-top: 0.6rem;
+      padding: 1rem 1.2rem;
+      border-radius: 12px;
+      background: rgba(76,175,80,0.1);
+      color: #1b5e20;
+      font-weight: 600;
+    }
+    canvas {
+      max-width: 100%;
+    }
+    .note {
+      font-size: 0.95rem;
+      color: #4a4a6a;
+    }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="page">
   <main class="container">
-    <h1>บทที่ 2: ข้อมูลและการสรุป</h1>
-    <p>ส่วนนี้เตรียมไว้สำหรับเนื้อหาฉบับเต็มของบทเรียน 2. เพิ่มตัวอย่างและกรณีศึกษาได้ตามต้องการ.</p>
+    <header class="hero">
+      <h1>บทเรียนที่ 2: หลักการนับเบื้องต้น (Counting Principles)</h1>
+      <p>เตรียมพร้อมก้าวสู่โลกของความน่าจะเป็นด้วยศิลปะแห่งการนับจำนวนวิธีที่เป็นไปได้อย่างเป็นระบบ ทั้งกฎการบวก การคูณ ไปจนถึงเครื่องมือขั้นสูงอย่าง Permutation และ Combination</p>
+    </header>
+
+    <section class="card" id="why-counting">
+      <h2><span class="badge">Step 1</span> ทำไมต้องเรียน “นับเลข”?</h2>
+      <p>ถึงแม้ทุกคนจะคุ้นเคยกับการนับตัวเลขตั้งแต่เด็ก แต่ในทางสถิติ “การนับ” คือการประเมินจำนวนวิธีทั้งหมดที่เป็นไปได้ของเหตุการณ์ที่ซับซ้อน เช่น การจัดตู้เสื้อผ้า การเลือกคณะกรรมการ หรือการสร้างรหัสผ่าน ซึ่งเป็นพื้นฐานสำคัญก่อนเข้าสู่การคำนวณความน่าจะเป็น</p>
+      <div class="highlight">
+        <strong>สถานการณ์ตัวอย่าง</strong>
+        <ul>
+          <li>มีเสื้อ 3 ตัว กางเกง 2 ตัว จะแต่งตัวได้ทั้งหมดกี่แบบ?</li>
+          <li>มีคน 10 คน จะเลือกกรรมการ 3 คนได้กี่วิธี?</li>
+          <li>จะสร้างรหัส ATM 4 หลักได้ทั้งหมดกี่รหัส?</li>
+        </ul>
+        <p>การนับแบบดั้งเดิมอาจช้าและผิดพลาดง่าย หลักการนับจึงช่วยให้เรามองภาพรวมและแก้ปัญหาอย่างเป็นขั้นตอน</p>
+      </div>
+    </section>
+
+    <section class="card" id="basic-rules">
+      <h2><span class="badge">Step 2</span> กฎพื้นฐาน: Addition &amp; Multiplication</h2>
+      <div class="columns two">
+        <article class="definition-card">
+          <strong>กฎการบวก (Addition Rule)</strong>
+          <p><em>ใช้เมื่อมีหลายทางเลือกที่เป็นไปได้อย่างใดอย่างหนึ่ง</em> หากแต่ละทางเลือกเป็นอิสระและไม่สามารถเกิดพร้อมกันได้ เรานับจำนวนวิธีของแต่ละทางเลือกแล้วบวกกัน</p>
+          <p class="note">คีย์เวิร์ด: “หรือ”, “อย่างใดอย่างหนึ่ง”</p>
+          <details class="lesson-toggle">
+            <summary>ตัวอย่าง: เมนูเครื่องดื่ม</summary>
+            <p>ร้านน้ำมีเมนูปั่น 4 แบบ และเมนูร้อน 3 แบบ ลูกค้าสามารถเลือกอย่างใดอย่างหนึ่งได้ทั้งหมด <strong>4 + 3 = 7 วิธี</strong></p>
+          </details>
+        </article>
+        <article class="definition-card">
+          <strong>กฎการคูณ (Multiplication Rule)</strong>
+          <p><em>ใช้เมื่อการทำงานประกอบด้วยหลายขั้นตอนที่ต้องทำต่อเนื่องกัน</em> นับจำนวนวิธีของแต่ละขั้นตอนแล้วยกผลคูณเพื่อหาจำนวนวิธีทั้งหมด</p>
+          <p class="note">คีย์เวิร์ด: “และ”, “ทำตามลำดับ”, “ต่อเนื่องกัน”</p>
+          <details class="lesson-toggle">
+            <summary>ตัวอย่าง: แต่งกาย</summary>
+            <p>เลือกเสื้อ 3 แบบ และเลือกกางเกง 4 แบบได้ <strong>3 × 4 = 12 วิธี</strong></p>
+          </details>
+        </article>
+      </div>
+
+      <div class="highlight">
+        <h3>ตัวอย่างกฎการคูณแบบโต้ตอบ</h3>
+        <p>ทดลองเปลี่ยนจำนวนเสื้อผ้าเพื่อดูจำนวนชุดแต่งกายที่เป็นไปได้!</p>
+        <div class="calculator" id="outfit-calculator">
+          <label>จำนวนเสื้อที่มี
+            <input type="number" id="shirts" value="3" min="0" />
+          </label>
+          <label>จำนวนกางเกงที่มี
+            <input type="number" id="pants" value="4" min="0" />
+          </label>
+          <button type="button" id="calcOutfit">คำนวณจำนวนชุดที่เป็นไปได้</button>
+          <p class="result-card" id="outfitResult">มีทั้งหมด 12 วิธีในการแต่งตัว</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card" id="advanced-tools">
+      <h2><span class="badge">Step 3</span> เครื่องมือขั้นสูง: Permutation &amp; Combination</h2>
+      <p>เมื่อจำนวนทางเลือกมากขึ้น เราใช้เครื่องมือที่ทรงพลังขึ้นเพื่อจัดการกับการเรียงลำดับและการจัดกลุ่มอย่างเป็นระบบ</p>
+
+      <div class="columns two">
+        <article class="definition-card">
+          <strong>Permutation (การเรียงสับเปลี่ยน)</strong>
+          <p>นำของที่แตกต่างกันทั้งหมด <code>n</code> ชิ้น มาเรียงลำดับเพียง <code>r</code> ชิ้น โดยลำดับมีความสำคัญ</p>
+          <div class="code-box">
+P<sub>n,r</sub> = \(\dfrac{n!}{(n-r)!}\)
+          </div>
+          <p class="note">หัวใจสำคัญ: การสลับตำแหน่งถือว่าเป็นอีกหนึ่งวิธี</p>
+        </article>
+        <article class="definition-card">
+          <strong>Combination (การจัดหมู่)</strong>
+          <p>เลือกของที่แตกต่างกันทั้งหมด <code>n</code> ชิ้น มาเป็นกลุ่มจำนวน <code>r</code> ชิ้น โดยไม่สนใจลำดับ</p>
+          <div class="code-box">
+C<sub>n,r</sub> = \(\binom{n}{r} = \dfrac{n!}{r!(n-r)!}\)
+          </div>
+          <p class="note">หัวใจสำคัญ: ได้ของครบตามจำนวนก็พอ ใครมาก่อนไม่สำคัญ</p>
+        </article>
+      </div>
+
+      <div class="columns two" id="pc-calculators">
+        <div>
+          <h3>คำนวณ Permutation</h3>
+          <div class="calculator">
+            <label>จำนวนทั้งหมด (n)
+              <input type="number" id="perm-n" value="8" min="0" />
+            </label>
+            <label>จำนวนที่เรียง (r)
+              <input type="number" id="perm-r" value="3" min="0" />
+            </label>
+            <button type="button" id="calcPerm">คำนวณ P<sub>n,r</sub></button>
+            <div class="result-card" id="permResult">P<sub>8,3</sub> = 336 วิธี</div>
+          </div>
+        </div>
+        <div>
+          <h3>คำนวณ Combination</h3>
+          <div class="calculator">
+            <label>จำนวนทั้งหมด (n)
+              <input type="number" id="comb-n" value="10" min="0" />
+            </label>
+            <label>จำนวนที่เลือก (r)
+              <input type="number" id="comb-r" value="3" min="0" />
+            </label>
+            <button type="button" id="calcComb">คำนวณ C<sub>n,r</sub></button>
+            <div class="result-card" id="combResult">C<sub>10,3</sub> = 120 วิธี</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card" style="background: rgba(255,255,255,0.6); margin-top: 2rem;">
+        <h3>กราฟเปรียบเทียบ Permutation vs Combination</h3>
+        <p>กราฟด้านล่างแสดงจำนวนวิธีของ P<sub>n,r</sub> และ C<sub>n,r</sub> เมื่อกำหนด n = 6 แล้วเปลี่ยนค่าของ r เพื่อเห็นความแตกต่างระหว่าง “สนใจลำดับ” และ “ไม่สนใจลำดับ”</p>
+        <canvas id="pcChart" height="220"></canvas>
+      </div>
+    </section>
+
+    <section class="card" id="understanding">
+      <h2><span class="badge">Step 4</span> เข้าใจความแตกต่างของ Permutation และ Combination</h2>
+      <p>คำถามหลักที่ช่วยจำแนกคือ <strong>“ลำดับสำคัญหรือไม่?”</strong></p>
+      <div class="columns two">
+        <div class="highlight">
+          <h3>Permutation: ลำดับสำคัญ</h3>
+          <ul>
+            <li>การแข่งขันวิ่ง: ผู้ชนะที่ 1, 2, 3 มีความหมายแตกต่างกัน</li>
+            <li>การจัดตำแหน่ง: ประธาน รองประธาน เหรัญญิก</li>
+          </ul>
+        </div>
+        <div class="highlight">
+          <h3>Combination: ลำดับไม่สำคัญ</h3>
+          <ul>
+            <li>เลือกคณะกรรมการ 3 คน: สนใจแค่ว่าได้ใครบ้าง</li>
+            <li>เลือกไพ่ 5 ใบ: ลำดับการหยิบไม่มีผลต่อไพ่ในมือ</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="card" id="examples">
+      <h2><span class="badge">Step 5</span> ตัวอย่างการประยุกต์</h2>
+      <div class="table-wrapper">
+        <table class="styled">
+          <thead>
+            <tr>
+              <th>สถานการณ์</th>
+              <th>การวิเคราะห์</th>
+              <th>วิธีคำนวณ</th>
+              <th>คำตอบ</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>กฎการคูณ: เสื้อ 3 แบบ × กางเกง 4 แบบ</td>
+              <td>สองขั้นตอนต่อเนื่อง เลือกเสื้อ แล้วเลือกกางเกง</td>
+              <td>3 × 4</td>
+              <td>12 วิธี</td>
+            </tr>
+            <tr>
+              <td>Permutation: นักวิ่ง 8 คน แข่งชิงเหรียญ 3 ตำแหน่ง</td>
+              <td>เลือกคน 3 คนจาก 8 คนและสนใจลำดับเข้าเส้นชัย</td>
+              <td>\(P_{8,3} = \frac{8!}{5!}\)</td>
+              <td>336 วิธี</td>
+            </tr>
+            <tr>
+              <td>Combination: เลือกตัวแทน 3 คนจากนักเรียน 10 คน</td>
+              <td>เลือกคน 3 คนโดยไม่สนใจลำดับ</td>
+              <td>\(C_{10,3} = \frac{10!}{3!7!}\)</td>
+              <td>120 วิธี</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="card" id="self-check">
+      <h2><span class="badge">Step 6</span> Self Check</h2>
+      <details class="lesson-toggle" open>
+        <summary>ลองตอบคำถามท้ายบท</summary>
+        <ol>
+          <li>หากร้านกาแฟมีเครื่องดื่มร้อน 5 ชนิด และเครื่องดื่มเย็น 8 ชนิด ลูกค้าสั่งเครื่องดื่มได้กี่แบบ? (ใช้กฎการบวก)</li>
+          <li>บริษัทต้องการจัดทีมงาน 4 ตำแหน่ง (หัวหน้า, ผู้ช่วย, วิศวกร, นักวิเคราะห์) จากพนักงานทั้งหมด 9 คน มีวิธีจัดกี่แบบ? (Permutation)</li>
+          <li>สโมสรอยากเลือกสมาชิก 5 คนจากทั้งหมด 12 คนเพื่อจัดทริป มีวิธีเลือกกี่แบบ? (Combination)</li>
+        </ol>
+        <p class="note">ลองใช้เครื่องคิดเลขด้านบนเพื่อเช็กคำตอบของคุณ!</p>
+      </details>
+    </section>
   </main>
+
+  <script>
+    const factorialMemo = new Map([[0, 1], [1, 1]]);
+    function factorial(n) {
+      if (n < 0) return NaN;
+      if (factorialMemo.has(n)) return factorialMemo.get(n);
+      let result = n * factorial(n - 1);
+      factorialMemo.set(n, result);
+      return result;
+    }
+
+    function updateOutfit() {
+      const shirts = Math.max(0, Number(document.getElementById('shirts').value || 0));
+      const pants = Math.max(0, Number(document.getElementById('pants').value || 0));
+      const ways = shirts * pants;
+      document.getElementById('outfitResult').textContent = `มีทั้งหมด ${ways.toLocaleString('th-TH')} วิธีในการแต่งตัว`;
+    }
+
+    function calcPermutation() {
+      const n = Number(document.getElementById('perm-n').value);
+      const r = Number(document.getElementById('perm-r').value);
+      if (r > n) {
+        document.getElementById('permResult').textContent = 'r ต้องไม่มากกว่า n';
+        return;
+      }
+      const value = factorial(n) / factorial(n - r);
+      document.getElementById('permResult').textContent = `Pₙ,ₚ = ${value.toLocaleString('th-TH')} วิธี`;
+    }
+
+    function calcCombination() {
+      const n = Number(document.getElementById('comb-n').value);
+      const r = Number(document.getElementById('comb-r').value);
+      if (r > n) {
+        document.getElementById('combResult').textContent = 'r ต้องไม่มากกว่า n';
+        return;
+      }
+      const value = factorial(n) / (factorial(r) * factorial(n - r));
+      document.getElementById('combResult').textContent = `Cₙ,ₚ = ${value.toLocaleString('th-TH')} วิธี`;
+    }
+
+    document.getElementById('calcOutfit').addEventListener('click', updateOutfit);
+    document.getElementById('calcPerm').addEventListener('click', calcPermutation);
+    document.getElementById('calcComb').addEventListener('click', calcCombination);
+
+    updateOutfit();
+    calcPermutation();
+    calcCombination();
+
+    const ctx = document.getElementById('pcChart');
+    if (ctx) {
+      const n = 6;
+      const labels = [1, 2, 3, 4, 5, 6];
+      const permutationData = labels.map(r => factorial(n) / factorial(n - r));
+      const combinationData = labels.map(r => factorial(n) / (factorial(r) * factorial(n - r)));
+      new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: labels.map(r => `r = ${r}`),
+          datasets: [
+            {
+              label: 'Permutation (P_{n,r})',
+              data: permutationData,
+              borderColor: '#512da8',
+              backgroundColor: 'rgba(81,45,168,0.2)',
+              tension: 0.35,
+              fill: true,
+              pointRadius: 4,
+              pointBackgroundColor: '#311b92'
+            },
+            {
+              label: 'Combination (C_{n,r})',
+              data: combinationData,
+              borderColor: '#ff7043',
+              backgroundColor: 'rgba(255,112,67,0.18)',
+              tension: 0.35,
+              fill: true,
+              pointRadius: 4,
+              pointBackgroundColor: '#e64a19'
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          plugins: {
+            legend: {
+              labels: {
+                font: { size: 13 }
+              }
+            },
+            tooltip: {
+              callbacks: {
+                label: ctx => `${ctx.dataset.label}: ${ctx.parsed.y.toLocaleString('th-TH')} วิธี`
+              }
+            }
+          },
+          scales: {
+            y: {
+              beginAtZero: true,
+              ticks: {
+                callback: value => value.toLocaleString('th-TH')
+              },
+              title: {
+                display: true,
+                text: 'จำนวนวิธี (ways)'
+              }
+            }
+          }
+        }
+      });
+    }
+  </script>
 </body>
 </html>

--- a/prob & Stats/content/03-probability-basics.html
+++ b/prob & Stats/content/03-probability-basics.html
@@ -2,13 +2,403 @@
 <html lang="th">
 <head>
   <meta charset="utf-8" />
-  <title>บทที่ 3: ความน่าจะเป็นเบื้องต้น</title>
+  <title>บทที่ 3: นิยามของความน่าจะเป็น</title>
   <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body.page {
+      background: linear-gradient(180deg, rgba(227,242,253,0.8), rgba(227,242,253,0.95));
+      min-height: 100vh;
+    }
+    header.hero {
+      background: linear-gradient(135deg, #0288d1, #26c6da);
+      color: #fff;
+      padding: 2.8rem clamp(1.2rem, 5vw, 4rem);
+      border-radius: 28px;
+      margin-bottom: 2rem;
+      position: relative;
+      overflow: hidden;
+      box-shadow: 0 24px 44px rgba(2,136,209,0.28);
+    }
+    header.hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 85% 15%, rgba(255,255,255,0.35), transparent 55%),
+                  radial-gradient(circle at 10% 20%, rgba(255,255,255,0.24), transparent 70%);
+      pointer-events: none;
+    }
+    header.hero h1 {
+      font-size: clamp(2.3rem, 3vw + 1.2rem, 3.6rem);
+    }
+    main.container {
+      padding-bottom: 6rem;
+    }
+    section.card {
+      background: rgba(255,255,255,0.9);
+      border-radius: 22px;
+      padding: clamp(1.4rem, 4vw, 2.4rem);
+      margin-bottom: 2rem;
+      box-shadow: 0 16px 34px rgba(2,119,189,0.12);
+      backdrop-filter: blur(5px);
+    }
+    h2 {
+      display: flex;
+      align-items: center;
+      gap: 0.8rem;
+      font-size: 1.9rem;
+      color: #01579b;
+    }
+    h2 .badge {
+      background: rgba(2,136,209,0.18);
+      color: #01579b;
+      border-radius: 999px;
+      padding: 0.15rem 0.85rem;
+      font-size: 1rem;
+      font-weight: 600;
+      letter-spacing: 0.4px;
+    }
+    .concept-grid {
+      display: grid;
+      gap: 1.5rem;
+    }
+    @media (min-width: 880px) {
+      .concept-grid.two { grid-template-columns: repeat(2, minmax(0,1fr)); }
+      .concept-grid.three { grid-template-columns: repeat(3, minmax(0,1fr)); }
+    }
+    article.definition {
+      border-radius: 16px;
+      padding: 1.4rem;
+      background: linear-gradient(160deg, rgba(227,242,253,0.65), rgba(224,247,250,0.75));
+      border: 1px solid rgba(2,136,209,0.18);
+      display: grid;
+      gap: 0.7rem;
+    }
+    article.definition strong {
+      font-size: 1.1rem;
+      color: #01579b;
+    }
+    .highlight {
+      border-left: 6px solid #03a9f4;
+      border-radius: 14px;
+      padding: 1.2rem 1.4rem;
+      background: rgba(3,169,244,0.08);
+      margin: 1rem 0;
+    }
+    .example-card {
+      border-radius: 18px;
+      background: rgba(1,135,134,0.08);
+      padding: 1.5rem;
+      border: 1px solid rgba(1,135,134,0.2);
+    }
+    .code-box {
+      background: #0d1b2a;
+      color: #e0f7fa;
+      border-radius: 12px;
+      padding: 1rem 1.2rem;
+      font-family: "Fira Code", "Courier New", monospace;
+      font-size: 0.95rem;
+    }
+    .note {
+      font-size: 0.92rem;
+      color: #33617a;
+    }
+    details.toggle {
+      background: rgba(1,135,134,0.12);
+      border-radius: 15px;
+      padding: 1rem 1.2rem;
+      border: 1px solid rgba(1,135,134,0.22);
+    }
+    details.toggle summary {
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .calculator {
+      display: grid;
+      gap: 1rem;
+      margin-top: 1rem;
+    }
+    .calculator label {
+      font-weight: 600;
+      color: #01579b;
+    }
+    .calculator input, .calculator textarea {
+      border-radius: 12px;
+      border: 1px solid rgba(2,136,209,0.35);
+      padding: 0.65rem 0.85rem;
+      font-size: 1rem;
+    }
+    .calculator button {
+      border-radius: 999px;
+      border: none;
+      background: linear-gradient(135deg, #0288d1, #00acc1);
+      color: #fff;
+      font-weight: 600;
+      padding: 0.75rem 1.6rem;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .calculator button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 22px rgba(2,136,209,0.3);
+    }
+    .result-card {
+      border-radius: 12px;
+      background: rgba(76,175,80,0.12);
+      color: #1b5e20;
+      font-weight: 600;
+      padding: 0.9rem 1.1rem;
+    }
+    canvas {
+      max-width: 100%;
+    }
+    .table-wrapper {
+      overflow-x: auto;
+      border-radius: 14px;
+      border: 1px solid rgba(2,136,209,0.12);
+    }
+    table.styled {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    table.styled th,
+    table.styled td {
+      padding: 0.9rem 1.1rem;
+      text-align: left;
+    }
+    table.styled thead {
+      background: rgba(2,136,209,0.16);
+      color: #01579b;
+    }
+    table.styled tbody tr:nth-child(even) {
+      background: rgba(2,136,209,0.06);
+    }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="page">
   <main class="container">
-    <h1>บทที่ 3: ความน่าจะเป็นเบื้องต้น</h1>
-    <p>ส่วนนี้เตรียมไว้สำหรับเนื้อหาฉบับเต็มของบทเรียน 3. เพิ่มตัวอย่างและกรณีศึกษาได้ตามต้องการ.</p>
+    <header class="hero">
+      <h1>บทเรียนที่ 3: นิยามของความน่าจะเป็น, แซมเปิลสเปซ, และเหตุการณ์</h1>
+      <p>นำหลักการนับจากบทที่แล้วมาประยุกต์เพื่อเข้าใจ “ความน่าจะเป็น” อย่างเป็นระบบ เรียนรู้คำศัพท์สำคัญ ทั้งการทดลองสุ่ม แซมเปิลสเปซ และเหตุการณ์ พร้อมคุณสมบัติที่ต้องจำให้ขึ้นใจ</p>
+    </header>
+
+    <section class="card" id="foundation">
+      <h2><span class="badge">Focus</span> คำศัพท์พื้นฐาน</h2>
+      <div class="concept-grid three">
+        <article class="definition">
+          <strong>การทดลองสุ่ม (Random Experiment)</strong>
+          <p>การกระทำที่เรารู้ว่าผลลัพธ์ที่เป็นไปได้มีอะไรบ้าง แต่ไม่สามารถบอกผลลัพธ์ที่จะเกิดในแต่ละครั้งได้แน่ชัด เช่น การโยนเหรียญ การทอดลูกเต๋า หรือการหยิบไพ่</p>
+        </article>
+        <article class="definition">
+          <strong>แซมเปิลสเปซ (Sample Space, S)</strong>
+          <p>เซตของผลลัพธ์ทั้งหมดที่เป็นไปได้จากการทดลองสุ่ม เช่น การโยนเหรียญ 1 ครั้ง S = {หัว, ก้อย}</p>
+        </article>
+        <article class="definition">
+          <strong>เหตุการณ์ (Event, E)</strong>
+          <p>ผลลัพธ์ที่เราสนใจซึ่งเป็นสับเซตของแซมเปิลสเปซ เช่น การทอดลูกเต๋า 1 ลูก เหตุการณ์ “ออกแต้มคู่” คือ E = {2, 4, 6}</p>
+        </article>
+      </div>
+
+      <div class="highlight">
+        <h3>ทดลองสร้างแซมเปิลสเปซด้วยตัวเอง</h3>
+        <p>กรอกผลลัพธ์ที่เป็นไปได้โดยคั่นด้วยเครื่องหมายจุลภาค ระบบจะสร้างตารางให้พร้อมบอกจำนวนผลลัพธ์ทั้งหมด</p>
+        <div class="calculator">
+          <label for="sample-input">ผลลัพธ์ทั้งหมด (คั่นด้วย , )</label>
+          <textarea id="sample-input" rows="2">หัว,ก้อย</textarea>
+          <button id="sample-btn" type="button">แสดงแซมเปิลสเปซ</button>
+          <div class="result-card" id="sample-result">S = {หัว, ก้อย} ⇒ n(S) = 2</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="card" id="definition">
+      <h2><span class="badge">Core</span> นิยามความน่าจะเป็น</h2>
+      <p>เมื่อเรารู้จัก S และ E แล้ว ความน่าจะเป็นของเหตุการณ์ใดๆ คือสัดส่วนระหว่างจำนวนผลลัพธ์ที่สนใจและจำนวนผลลัพธ์ทั้งหมด</p>
+      <div class="code-box">
+P(E) = \(\dfrac{n(E)}{n(S)}\)  , 0 ≤ P(E) ≤ 1
+      </div>
+      <p class="note">P(E)=0 หมายถึงเหตุการณ์ไม่สามารถเกิดขึ้นได้เลย ในขณะที่ P(E)=1 แปลว่าเหตุการณ์นั้นต้องเกิดขึ้นแน่นอน</p>
+
+      <div class="highlight">
+        <h3>ตัวอย่าง: ทอดลูกเต๋า 1 ลูก</h3>
+        <ul>
+          <li>S = {1, 2, 3, 4, 5, 6} ⇒ n(S) = 6</li>
+          <li>E = {1, 3, 5} (แต้มคี่) ⇒ n(E) = 3</li>
+          <li>ดังนั้น P(E) = 3/6 = 0.5</li>
+        </ul>
+      </div>
+
+      <div class="example-card">
+        <h3>เครื่องคิดเลขความน่าจะเป็นแบบกำหนดเอง</h3>
+        <div class="calculator">
+          <label>จำนวนผลลัพธ์ที่สนใจ n(E)
+            <input type="number" id="event-count" value="3" min="0" />
+          </label>
+          <label>จำนวนผลลัพธ์ทั้งหมด n(S)
+            <input type="number" id="space-count" value="6" min="1" />
+          </label>
+          <button id="prob-btn" type="button">คำนวณความน่าจะเป็น</button>
+          <div class="result-card" id="prob-result">P(E) = 0.5 (50%)</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="card" id="properties">
+      <h2><span class="badge">Insight</span> คุณสมบัติสำคัญของความน่าจะเป็น</h2>
+      <p>ไม่ว่าจะใช้สูตรใด ค่าความน่าจะเป็นจะต้องปฏิบัติตามกฎต่อไปนี้เสมอ</p>
+      <ul>
+        <li><strong>0 ≤ P(E) ≤ 1</strong>: โอกาสไม่มีทางติดลบหรือมากกว่า 100%</li>
+        <li><strong>P(S) = 1</strong>: ต้องเกิดผลลัพธ์บางอย่างในแซมเปิลสเปซแน่นอน</li>
+        <li><strong>กฎการบวกสำหรับเหตุการณ์ที่ไม่เกิดร่วมกัน</strong>: หาก A และ B ไม่เกิดร่วมกัน P(A ∪ B) = P(A) + P(B)</li>
+      </ul>
+
+      <div class="card" style="background: rgba(255,255,255,0.65); margin-top: 1.4rem;">
+        <h3>แผนภาพโอกาส (Interactive)</h3>
+        <p>เลื่อนสไลด์เพื่อดูการเปลี่ยนแปลงของความน่าจะเป็นของเหตุการณ์ A และ B รวมถึง P(A ∪ B)</p>
+        <div class="calculator">
+          <label>P(A) (%) <input type="range" id="prob-a" min="0" max="100" value="40"></label>
+          <label>P(B) (%) <input type="range" id="prob-b" min="0" max="100" value="35"></label>
+          <label>P(A ∩ B) (%) <input type="range" id="prob-ab" min="0" max="100" value="10"></label>
+          <div class="result-card" id="union-result">P(A ∪ B) = 0.65</div>
+        </div>
+        <canvas id="vennChart" height="220"></canvas>
+        <p class="note">ข้อควรจำ: P(A ∩ B) ต้องไม่เกินค่าที่เล็กที่สุดระหว่าง P(A) และ P(B) เพื่อให้สอดคล้องกับความจริง</p>
+      </div>
+    </section>
+
+    <section class="card" id="examples">
+      <h2><span class="badge">Practice</span> ตัวอย่างโจทย์</h2>
+      <div class="table-wrapper">
+        <table class="styled">
+          <thead>
+            <tr>
+              <th>สถานการณ์</th>
+              <th>การวิเคราะห์</th>
+              <th>ผลลัพธ์</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>ทอดลูกเต๋า 1 ลูก ต้องการแต้มคี่</td>
+              <td>S = {1..6}, E = {1,3,5}, n(E)=3, n(S)=6</td>
+              <td>P(E)=0.5</td>
+            </tr>
+            <tr>
+              <td>หยิบลูกบอลสีแดงจากกล่อง (แดง 5, ขาว 3)</td>
+              <td>n(S)=8, n(E)=5</td>
+              <td>P(E) = 5/8 ≈ 0.625</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <details class="toggle" open>
+        <summary>บทสรุป</summary>
+        <p>ความน่าจะเป็นเป็นเครื่องมือวัดโอกาสของเหตุการณ์ โดยใช้หลักการนับเพื่อหา n(E) และ n(S) และต้องยึดคุณสมบัติพื้นฐานทั้งสามข้อเป็นหลักเสมอ</p>
+      </details>
+    </section>
   </main>
+
+  <script>
+    const sampleBtn = document.getElementById('sample-btn');
+    const sampleInput = document.getElementById('sample-input');
+    const sampleResult = document.getElementById('sample-result');
+
+    function updateSampleSpace() {
+      const items = sampleInput.value
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean);
+      if (!items.length) {
+        sampleResult.textContent = 'กรุณากรอกผลลัพธ์อย่างน้อย 1 ค่า';
+        return;
+      }
+      const uniqueItems = [...new Set(items)];
+      sampleResult.textContent = `S = {${uniqueItems.join(', ')}} ⇒ n(S) = ${uniqueItems.length}`;
+    }
+
+    sampleBtn.addEventListener('click', updateSampleSpace);
+    updateSampleSpace();
+
+    const probBtn = document.getElementById('prob-btn');
+    const eventCount = document.getElementById('event-count');
+    const spaceCount = document.getElementById('space-count');
+    const probResult = document.getElementById('prob-result');
+
+    function calcProbability() {
+      const e = Number(eventCount.value);
+      const s = Number(spaceCount.value);
+      if (!Number.isFinite(e) || !Number.isFinite(s) || s <= 0) {
+        probResult.textContent = 'กรุณากรอกค่าที่ถูกต้อง';
+        return;
+      }
+      if (e > s) {
+        probResult.textContent = 'n(E) ต้องไม่มากกว่า n(S)';
+        return;
+      }
+      const value = e / s;
+      probResult.textContent = `P(E) = ${value.toFixed(4)} (${(value * 100).toFixed(2)}%)`;
+    }
+
+    probBtn.addEventListener('click', calcProbability);
+    calcProbability();
+
+    const probA = document.getElementById('prob-a');
+    const probB = document.getElementById('prob-b');
+    const probAB = document.getElementById('prob-ab');
+    const unionResult = document.getElementById('union-result');
+
+    function clampIntersection() {
+      const maxAllowed = Math.min(Number(probA.value), Number(probB.value));
+      if (Number(probAB.value) > maxAllowed) {
+        probAB.value = maxAllowed;
+      }
+    }
+
+    function updateUnion() {
+      clampIntersection();
+      const pA = Number(probA.value) / 100;
+      const pB = Number(probB.value) / 100;
+      const pAB = Number(probAB.value) / 100;
+      const union = pA + pB - pAB;
+      unionResult.textContent = `P(A ∪ B) = ${union.toFixed(3)}`;
+      vennChart.data.datasets[0].data = [pA - pAB, pAB, pB - pAB];
+      vennChart.update();
+    }
+
+    const ctx = document.getElementById('vennChart');
+    const vennChart = new Chart(ctx, {
+      type: 'doughnut',
+      data: {
+        labels: ['A เท่านั้น', 'A ∩ B', 'B เท่านั้น'],
+        datasets: [
+          {
+            data: [0.3, 0.1, 0.25],
+            backgroundColor: ['rgba(2,136,209,0.5)', 'rgba(0,188,212,0.6)', 'rgba(38,198,218,0.5)'],
+            borderColor: 'rgba(255,255,255,0.8)',
+            borderWidth: 2
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        cutout: '55%',
+        plugins: {
+          legend: { position: 'bottom' },
+          tooltip: {
+            callbacks: {
+              label: ctx => `${ctx.label}: ${(ctx.parsed * 100).toFixed(1)}%`
+            }
+          }
+        }
+      }
+    });
+
+    [probA, probB, probAB].forEach(slider => slider.addEventListener('input', updateUnion));
+    updateUnion();
+  </script>
 </body>
 </html>

--- a/prob & Stats/content/04-conditional.html
+++ b/prob & Stats/content/04-conditional.html
@@ -4,11 +4,408 @@
   <meta charset="utf-8" />
   <title>บทที่ 4: ความน่าจะเป็นแบบมีเงื่อนไข</title>
   <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body.page {
+      background: linear-gradient(180deg, rgba(255,245,235,0.9), rgba(255,253,231,0.9));
+      min-height: 100vh;
+    }
+    header.hero {
+      background: linear-gradient(135deg, #ff9800, #ffb74d);
+      color: #3e2723;
+      padding: clamp(2.4rem, 5vw, 3.4rem);
+      border-radius: 26px;
+      margin-bottom: 2.2rem;
+      box-shadow: 0 22px 45px rgba(255, 152, 0, 0.25);
+      position: relative;
+      overflow: hidden;
+    }
+    header.hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 75% 25%, rgba(255,255,255,0.34), transparent 60%),
+                  radial-gradient(circle at 15% 25%, rgba(255,255,255,0.22), transparent 70%);
+    }
+    header.hero h1 {
+      font-size: clamp(2.4rem, 3vw + 1.4rem, 3.7rem);
+    }
+    section.card {
+      background: rgba(255,255,255,0.93);
+      border-radius: 22px;
+      padding: clamp(1.4rem, 4vw, 2.6rem);
+      margin-bottom: 2.1rem;
+      box-shadow: 0 16px 36px rgba(230, 81, 0, 0.16);
+    }
+    h2 {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      color: #e65100;
+      font-size: 1.85rem;
+    }
+    h2 .badge {
+      padding: 0.1rem 0.85rem;
+      border-radius: 999px;
+      background: rgba(255, 152, 0, 0.15);
+      font-size: 1rem;
+      font-weight: 600;
+      letter-spacing: 0.4px;
+      color: #d84315;
+    }
+    .definition-grid {
+      display: grid;
+      gap: 1.4rem;
+    }
+    @media (min-width: 880px) {
+      .definition-grid.two { grid-template-columns: repeat(2, minmax(0,1fr)); }
+      .definition-grid.three { grid-template-columns: repeat(3, minmax(0,1fr)); }
+    }
+    .definition-card {
+      background: linear-gradient(150deg, rgba(255,224,178,0.6), rgba(255,249,196,0.7));
+      border: 1px solid rgba(255, 171, 64, 0.28);
+      border-radius: 18px;
+      padding: 1.4rem;
+      display: grid;
+      gap: 0.6rem;
+    }
+    .definition-card strong {
+      font-size: 1.12rem;
+      color: #bf360c;
+    }
+    .highlight {
+      padding: 1.2rem 1.4rem;
+      border-left: 6px solid #fb8c00;
+      background: rgba(255, 183, 77, 0.15);
+      border-radius: 14px;
+    }
+    .code-box {
+      background: #311b0b;
+      color: #ffecb3;
+      font-family: "Fira Code", "Courier New", monospace;
+      border-radius: 12px;
+      padding: 1rem 1.2rem;
+      font-size: 0.96rem;
+      overflow-x: auto;
+    }
+    .calculator {
+      display: grid;
+      gap: 1rem;
+      margin-top: 1rem;
+    }
+    .calculator label {
+      font-weight: 600;
+      color: #e65100;
+    }
+    .calculator input {
+      border-radius: 12px;
+      border: 1px solid rgba(230, 81, 0, 0.4);
+      padding: 0.65rem 0.9rem;
+    }
+    .calculator button {
+      border-radius: 999px;
+      border: none;
+      background: linear-gradient(135deg, #ef6c00, #fb8c00);
+      color: #fff8e1;
+      font-weight: 600;
+      padding: 0.75rem 1.6rem;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .calculator button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 20px rgba(239, 108, 0, 0.26);
+    }
+    .result-card {
+      border-radius: 12px;
+      padding: 1rem 1.2rem;
+      background: rgba(56,142,60,0.12);
+      color: #1b5e20;
+      font-weight: 600;
+    }
+    .note {
+      font-size: 0.92rem;
+      color: #6d4c41;
+    }
+    .table-wrapper {
+      overflow-x: auto;
+      border-radius: 14px;
+      border: 1px solid rgba(255, 183, 77, 0.22);
+    }
+    table.styled {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    table.styled th,
+    table.styled td {
+      padding: 0.9rem 1.1rem;
+      text-align: left;
+    }
+    table.styled thead {
+      background: rgba(255, 183, 77, 0.22);
+      color: #e65100;
+    }
+    table.styled tbody tr:nth-child(even) {
+      background: rgba(255, 224, 178, 0.25);
+    }
+    details.toggle {
+      background: rgba(255, 224, 178, 0.28);
+      border-radius: 16px;
+      padding: 1rem 1.2rem;
+      border: 1px solid rgba(255, 171, 64, 0.3);
+    }
+    details.toggle summary {
+      cursor: pointer;
+      font-weight: 600;
+    }
+    canvas {
+      max-width: 100%;
+    }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="page">
   <main class="container">
-    <h1>บทที่ 4: ความน่าจะเป็นแบบมีเงื่อนไข</h1>
-    <p>ส่วนนี้เตรียมไว้สำหรับเนื้อหาฉบับเต็มของบทเรียน 4. เพิ่มตัวอย่างและกรณีศึกษาได้ตามต้องการ.</p>
+    <header class="hero">
+      <h1>บทเรียนที่ 4: ความน่าจะเป็นแบบมีเงื่อนไขและกฎที่เกี่ยวข้อง</h1>
+      <p>เข้าใจสถานการณ์ที่เหตุการณ์มีผลต่อกัน ใช้สูตร P(A|B) เพื่ออัปเดตความเชื่อและประเมินโอกาสเมื่อมีข้อมูลใหม่ พร้อมเรียนรู้กฎการคูณ การบวก เหตุการณ์อิสระ และเหตุการณ์ไม่เกิดร่วมกัน</p>
+    </header>
+
+    <section class="card" id="conditional-intro">
+      <h2><span class="badge">Step 1</span> ทำความรู้จัก P(A|B)</h2>
+      <p>ความน่าจะเป็นแบบมีเงื่อนไขคือโอกาสที่เหตุการณ์ A จะเกิดขึ้นเมื่อทราบว่าเหตุการณ์ B เกิดขึ้นแล้ว ตัวอย่างเช่น เมื่อเห็นเมฆดำเต็มท้องฟ้า โอกาสฝนตกจะมากขึ้นกว่าปกติ</p>
+      <div class="highlight">
+        <strong>สัญลักษณ์:</strong> P(A|B) อ่านว่า “ความน่าจะเป็นของ A เมื่อกำหนดว่า B เกิดขึ้นแล้ว”</div>
+    </section>
+
+    <section class="card" id="formulas">
+      <h2><span class="badge">Step 2</span> สูตรสำคัญ</h2>
+      <div class="definition-grid two">
+        <article class="definition-card">
+          <strong>สูตรความน่าจะเป็นแบบมีเงื่อนไข</strong>
+          <div class="code-box">
+P(A|B) = \(\dfrac{P(A \cap B)}{P(B)}\), &nbsp; P(B) > 0
+          </div>
+          <p>ปรับมุมมองให้ B กลายเป็นแซมเปิลสเปซใหม่ แล้วประเมินโอกาสที่ A จะเกิดในบริบทนั้น</p>
+        </article>
+        <article class="definition-card">
+          <strong>กฎการคูณ</strong>
+          <div class="code-box">
+P(A \cap B) = P(B) · P(A|B) = P(A) · P(B|A)
+          </div>
+          <p>ใช้หาโอกาสที่ A และ B จะเกิดพร้อมกัน โดยเลือกมองจาก A หรือ B ก่อนก็ได้</p>
+        </article>
+      </div>
+      <div class="definition-grid two" style="margin-top: 1.2rem;">
+        <article class="definition-card">
+          <strong>เหตุการณ์อิสระ (Independent Events)</strong>
+          <p>การเกิดของ A ไม่ส่งผลต่อความน่าจะเป็นของ B: P(A|B) = P(A)</p>
+          <div class="code-box">
+เมื่อ A และ B เป็นอิสระ ⇒ P(A \cap B) = P(A) · P(B)
+          </div>
+        </article>
+        <article class="definition-card">
+          <strong>กฎการบวกทั่วไป</strong>
+          <div class="code-box">
+P(A ∪ B) = P(A) + P(B) − P(A ∩ B)
+          </div>
+          <p>บวกโอกาสของแต่ละเหตุการณ์แล้วลบส่วนที่นับซ้ำ (A ∩ B)</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="card" id="independent-exclusive">
+      <h2><span class="badge">Step 3</span> แยกให้ออก: Independent vs Mutually Exclusive</h2>
+      <div class="definition-grid two">
+        <div class="highlight">
+          <h3>Independent</h3>
+          <ul>
+            <li>การโยนเหรียญครั้งที่ 1 และครั้งที่ 2: ผลลัพธ์ไม่เกี่ยวข้องกัน</li>
+            <li>ใช้สูตร P(A ∩ B) = P(A)P(B)</li>
+            <li>สามารถเกิดพร้อมกันได้</li>
+          </ul>
+        </div>
+        <div class="highlight">
+          <h3>Mutually Exclusive</h3>
+          <ul>
+            <li>ทอดลูกเต๋าครั้งเดียว: ได้แต้ม 1 กับ 6 พร้อมกันไม่ได้</li>
+            <li>การเกิดของ A ทำให้ B เกิดไม่ได้ทันที</li>
+            <li>P(A ∩ B) = 0</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="card" id="interactive-tools">
+      <h2><span class="badge">Step 4</span> เครื่องมือโต้ตอบ</h2>
+      <div class="definition-grid two">
+        <div class="card" style="background: rgba(255,224,178,0.45);">
+          <h3>คำนวณ P(A|B)</h3>
+          <div class="calculator">
+            <label>P(A ∩ B)
+              <input type="number" id="joint" value="0.3" step="0.01" min="0" max="1" />
+            </label>
+            <label>P(B)
+              <input type="number" id="pb" value="0.5" step="0.01" min="0" max="1" />
+            </label>
+            <button type="button" id="calcConditional">คำนวณ</button>
+            <div class="result-card" id="conditionalResult">P(A|B) = 0.600</div>
+          </div>
+        </div>
+        <div class="card" style="background: rgba(255,224,178,0.45);">
+          <h3>อัปเดตความน่าจะเป็นของเหตุการณ์ผลไม้</h3>
+          <p class="note">ใช้ตัวอย่างตะกร้าผลไม้: แอปเปิ้ลสีแดง 3 ผล, แอปเปิ้ลสีเขียว 1 ผล, ส้มสีแดง 2 ผล, ส้มสีเขียว 4 ผล</p>
+          <div class="calculator">
+            <label>เลือกรายการที่สนใจ
+              <select id="fruit-select">
+                <option value="apple">หยิบได้แอปเปิ้ลเมื่อรู้ว่าเป็นสีแดง</option>
+                <option value="orange">หยิบได้ส้มเมื่อรู้ว่าเป็นสีเขียว</option>
+                <option value="red">หยิบได้ผลไม้สีแดงหรือแอปเปิ้ล</option>
+              </select>
+            </label>
+            <div class="result-card" id="fruitResult">P(A|B) = 0.600</div>
+          </div>
+        </div>
+      </div>
+      <canvas id="conditionalChart" height="220" style="margin-top: 2rem;"></canvas>
+    </section>
+
+    <section class="card" id="examples">
+      <h2><span class="badge">Step 5</span> ตัวอย่างโจทย์พร้อมเฉลย</h2>
+      <div class="table-wrapper">
+        <table class="styled">
+          <thead>
+            <tr>
+              <th>โจทย์</th>
+              <th>การวิเคราะห์</th>
+              <th>คำตอบ</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>คำนวณ P(A|B) จากตะกร้าผลไม้เมื่อรู้ว่าได้ผลไม้สีแดง</td>
+              <td>P(A ∩ B) = 3/10, P(B) = 5/10</td>
+              <td>P(A|B) = 0.6</td>
+            </tr>
+            <tr>
+              <td>หา P(A ∪ B) สำหรับ “แอปเปิ้ล” หรือ “สีแดง”</td>
+              <td>P(A)=4/10, P(B)=5/10, P(A∩B)=3/10</td>
+              <td>P(A ∪ B) = 0.6</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <details class="toggle" open>
+        <summary>บทสรุป</summary>
+        <p>P(A|B) ช่วยให้เราปรับค่าความน่าจะเป็นตามข้อมูลใหม่ กฎการคูณและการบวกเป็นเครื่องมือสำคัญในการวิเคราะห์เหตุการณ์ที่สัมพันธ์กัน ส่วนการแยกแยะ Independent กับ Mutually Exclusive จะช่วยป้องกันความสับสนในการเลือกใช้สูตร</p>
+      </details>
+    </section>
   </main>
+
+  <script>
+    const jointInput = document.getElementById('joint');
+    const pbInput = document.getElementById('pb');
+    const conditionalResult = document.getElementById('conditionalResult');
+
+    function calcConditionalProb() {
+      const joint = Number(jointInput.value);
+      const pb = Number(pbInput.value);
+      if (pb <= 0 || joint < 0 || joint > pb) {
+        conditionalResult.textContent = 'กรุณากรอกค่าที่ถูกต้อง (0 ≤ P(A ∩ B) ≤ P(B))';
+        return;
+      }
+      const value = joint / pb;
+      conditionalResult.textContent = `P(A|B) = ${value.toFixed(3)}`;
+    }
+
+    document.getElementById('calcConditional').addEventListener('click', calcConditionalProb);
+    calcConditionalProb();
+
+    const fruitSelect = document.getElementById('fruit-select');
+    const fruitResult = document.getElementById('fruitResult');
+
+    const fruitData = {
+      total: 10,
+      appleRed: 3,
+      appleGreen: 1,
+      orangeRed: 2,
+      orangeGreen: 4
+    };
+
+    function updateFruitScenario() {
+      const choice = fruitSelect.value;
+      let message = '';
+      if (choice === 'apple') {
+        const pJoint = fruitData.appleRed / fruitData.total;
+        const pB = (fruitData.appleRed + fruitData.orangeRed) / fruitData.total;
+        message = `P(แอปเปิ้ล | สีแดง) = ${(pJoint / pB).toFixed(3)} (หรือ ${(pJoint / pB * 100).toFixed(1)}%)`;
+      } else if (choice === 'orange') {
+        const pJoint = fruitData.orangeGreen / fruitData.total;
+        const pB = (fruitData.appleGreen + fruitData.orangeGreen) / fruitData.total;
+        message = `P(ส้ม | สีเขียว) = ${(pJoint / pB).toFixed(3)}`;
+      } else {
+        const pA = (fruitData.appleRed + fruitData.appleGreen) / fruitData.total;
+        const pB = (fruitData.appleRed + fruitData.orangeRed) / fruitData.total;
+        const pJoint = fruitData.appleRed / fruitData.total;
+        message = `P(แอปเปิ้ล ∪ สีแดง) = ${(pA + pB - pJoint).toFixed(3)}`;
+      }
+      fruitResult.textContent = message;
+      updateChart(choice);
+    }
+
+    fruitSelect.addEventListener('change', updateFruitScenario);
+    updateFruitScenario();
+
+    const ctx = document.getElementById('conditionalChart');
+    const conditionalChart = new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: ['แอปเปิ้ลแดง', 'แอปเปิ้ลเขียว', 'ส้มแดง', 'ส้มเขียว'],
+        datasets: [
+          {
+            label: 'จำนวนผลไม้',
+            data: [fruitData.appleRed, fruitData.appleGreen, fruitData.orangeRed, fruitData.orangeGreen],
+            backgroundColor: ['#fb8c00', '#ffa726', '#ff7043', '#ffcc80'],
+            borderRadius: 12
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            callbacks: {
+              label: ctx => `${ctx.label}: ${ctx.parsed.y} ผล`
+            }
+          }
+        },
+        scales: {
+          y: {
+            beginAtZero: true,
+            ticks: {
+              precision: 0
+            },
+            title: {
+              display: true,
+              text: 'จำนวนผลไม้'
+            }
+          }
+        }
+      }
+    });
+
+    function updateChart(choice) {
+      const highlightColor = '#f4511e';
+      const baseColors = ['#fb8c00', '#ffa726', '#ff7043', '#ffcc80'];
+      let highlightIndex = -1;
+      if (choice === 'apple') highlightIndex = 0;
+      else if (choice === 'orange') highlightIndex = 3;
+      conditionalChart.data.datasets[0].backgroundColor = baseColors.map((c, idx) => idx === highlightIndex ? highlightColor : c);
+      conditionalChart.update();
+    }
+  </script>
 </body>
 </html>

--- a/prob & Stats/content/05-random-variables.html
+++ b/prob & Stats/content/05-random-variables.html
@@ -4,11 +4,374 @@
   <meta charset="utf-8" />
   <title>บทที่ 5: ตัวแปรสุ่ม</title>
   <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body.page {
+      min-height: 100vh;
+      background: linear-gradient(180deg, rgba(236,253,245,0.92), rgba(232,245,233,0.92));
+    }
+    header.hero {
+      background: linear-gradient(130deg, #43a047, #66bb6a);
+      color: #fff;
+      padding: clamp(2.5rem, 5vw, 3.5rem);
+      border-radius: 28px;
+      margin-bottom: 2.2rem;
+      position: relative;
+      overflow: hidden;
+      box-shadow: 0 24px 44px rgba(67,160,71,0.28);
+    }
+    header.hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 85% 15%, rgba(255,255,255,0.3), transparent 60%),
+                  radial-gradient(circle at 15% 30%, rgba(255,255,255,0.22), transparent 70%);
+    }
+    header.hero h1 {
+      font-size: clamp(2.4rem, 3vw + 1.4rem, 3.6rem);
+    }
+    section.card {
+      background: rgba(255,255,255,0.92);
+      border-radius: 24px;
+      padding: clamp(1.5rem, 4vw, 2.7rem);
+      margin-bottom: 2rem;
+      box-shadow: 0 18px 34px rgba(46, 125, 50, 0.18);
+      backdrop-filter: blur(5px);
+    }
+    h2 {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 1.9rem;
+      color: #1b5e20;
+    }
+    h2 .badge {
+      border-radius: 999px;
+      padding: 0.15rem 0.85rem;
+      background: rgba(200,230,201,0.8);
+      color: #1b5e20;
+      font-weight: 600;
+    }
+    .grid {
+      display: grid;
+      gap: 1.5rem;
+    }
+    @media (min-width: 880px) {
+      .grid.two { grid-template-columns: repeat(2, minmax(0,1fr)); }
+      .grid.three { grid-template-columns: repeat(3, minmax(0,1fr)); }
+    }
+    article.definition {
+      border-radius: 18px;
+      padding: 1.4rem;
+      background: linear-gradient(160deg, rgba(200,230,201,0.6), rgba(232,245,233,0.72));
+      border: 1px solid rgba(46,125,50,0.18);
+      display: grid;
+      gap: 0.65rem;
+    }
+    article.definition strong {
+      font-size: 1.12rem;
+      color: #2e7d32;
+    }
+    .highlight {
+      padding: 1.2rem 1.5rem;
+      border-left: 6px solid #43a047;
+      background: rgba(76,175,80,0.12);
+      border-radius: 16px;
+    }
+    .note {
+      color: #2e7d32;
+      font-size: 0.95rem;
+    }
+    .code-box {
+      background: #0b2b19;
+      color: #c8e6c9;
+      padding: 1.1rem 1.3rem;
+      border-radius: 14px;
+      font-family: "Fira Code", "Consolas", monospace;
+      font-size: 0.95rem;
+      overflow-x: auto;
+    }
+    .calculator {
+      display: grid;
+      gap: 1rem;
+      margin-top: 1rem;
+    }
+    .calculator label {
+      font-weight: 600;
+      color: #1b5e20;
+    }
+    .calculator input,
+    .calculator textarea,
+    .calculator select {
+      border-radius: 12px;
+      border: 1px solid rgba(46, 125, 50, 0.35);
+      padding: 0.65rem 0.9rem;
+      font-size: 1rem;
+    }
+    .calculator button {
+      border: none;
+      border-radius: 999px;
+      background: linear-gradient(135deg, #388e3c, #66bb6a);
+      color: #f1f8e9;
+      padding: 0.75rem 1.6rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .calculator button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 24px rgba(56,142,60,0.3);
+    }
+    .result-card {
+      border-radius: 14px;
+      background: rgba(0,150,136,0.12);
+      color: #004d40;
+      padding: 1rem 1.2rem;
+      font-weight: 600;
+    }
+    .table-wrapper {
+      overflow-x: auto;
+      border-radius: 14px;
+      border: 1px solid rgba(56,142,60,0.16);
+    }
+    table.styled {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    table.styled th,
+    table.styled td {
+      padding: 0.9rem 1.15rem;
+      text-align: left;
+    }
+    table.styled thead {
+      background: rgba(165,214,167,0.4);
+      color: #1b5e20;
+    }
+    table.styled tbody tr:nth-child(even) {
+      background: rgba(200,230,201,0.45);
+    }
+    details.toggle {
+      background: rgba(200,230,201,0.38);
+      border-radius: 16px;
+      padding: 1rem 1.2rem;
+      border: 1px solid rgba(165,214,167,0.4);
+    }
+    details.toggle summary {
+      cursor: pointer;
+      font-weight: 600;
+    }
+    canvas {
+      max-width: 100%;
+    }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="page">
   <main class="container">
-    <h1>บทที่ 5: ตัวแปรสุ่ม</h1>
-    <p>ส่วนนี้เตรียมไว้สำหรับเนื้อหาฉบับเต็มของบทเรียน 5. เพิ่มตัวอย่างและกรณีศึกษาได้ตามต้องการ.</p>
+    <header class="hero">
+      <h1>บทเรียนที่ 5: ตัวแปรสุ่ม (Random Variables)</h1>
+      <p>เปลี่ยนผลลัพธ์ของการทดลองสุ่มให้กลายเป็นตัวเลขที่ใช้วิเคราะห์ต่อได้ รู้จักประเภทของตัวแปรสุ่ม การแจกแจงความน่าจะเป็น และตัวอย่างที่จับต้องได้จากการโยนเหรียญ</p>
+    </header>
+
+    <section class="card" id="what-is-rv">
+      <h2><span class="badge">Step 1</span> ตัวแปรสุ่มคืออะไร?</h2>
+      <p>ตัวแปรสุ่มคือฟังก์ชันที่พาผลลัพธ์ของการทดลองสุ่ม (ซึ่งอาจไม่เป็นตัวเลข) ไปสู่ตัวเลขที่เราสนใจ เช่น นับจำนวนครั้งที่เหรียญออกหัวจากการโยนสองครั้ง</p>
+      <div class="highlight">
+        <h3>ตัวอย่าง: โยนเหรียญ 2 ครั้ง</h3>
+        <ul>
+          <li>S = {HH, HT, TH, TT}</li>
+          <li>กำหนด X = จำนวนหัว ⇒ X สามารถเป็น 0, 1, 2</li>
+          <li>HH → X=2, HT หรือ TH → X=1, TT → X=0</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="card" id="types">
+      <h2><span class="badge">Step 2</span> ประเภทของตัวแปรสุ่ม</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>ตัวแปรสุ่มแบบไม่ต่อเนื่อง (Discrete)</strong>
+          <p>มีค่าที่เป็นจำนวนที่นับได้ เช่น 0, 1, 2,... เหมาะกับเหตุการณ์ที่นับจำนวนครั้งหรือจำนวนชิ้น</p>
+          <div class="highlight">
+            <ul>
+              <li>X = จำนวนแต้ม 6 จากการทอดลูกเต๋า 10 ครั้ง</li>
+              <li>Y = จำนวนลูกค้าที่เข้าร้านใน 1 ชั่วโมง</li>
+              <li>Z = จำนวนสินค้าที่ชำรุดจาก 100 ชิ้น</li>
+            </ul>
+          </div>
+        </article>
+        <article class="definition">
+          <strong>ตัวแปรสุ่มแบบต่อเนื่อง (Continuous)</strong>
+          <p>มีค่าได้ทุกจำนวนในช่วงที่สนใจ เช่น มีทศนิยมไม่จำกัด เหมาะกับค่าที่เกิดจากการวัด</p>
+          <div class="highlight">
+            <ul>
+              <li>X = น้ำหนักของนักศึกษา</li>
+              <li>Y = อุณหภูมิห้อง</li>
+              <li>Z = เวลาวิ่งมาราธอน</li>
+            </ul>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="card" id="distribution">
+      <h2><span class="badge">Step 3</span> การแจกแจงความน่าจะเป็น</h2>
+      <p>เมื่อกำหนดตัวแปรสุ่ม เราต้องการทราบโอกาสของแต่ละค่าที่เป็นไปได้ ซึ่งแสดงผ่าน PMF หรือ PDF</p>
+      <div class="grid two">
+        <article class="definition">
+          <strong>Discrete: Probability Mass Function (PMF)</strong>
+          <div class="code-box">f(x) = P(X = x)</div>
+          <p class="note">คุณสมบัติ: f(x) ≥ 0 และผลรวมของ f(x) ทุกค่าต้องเท่ากับ 1</p>
+        </article>
+        <article class="definition">
+          <strong>Continuous: Probability Density Function (PDF)</strong>
+          <div class="code-box">P(a &lt; X &lt; b) = ∫<sub>a</sub><sup>b</sup> f(x) dx</div>
+          <p class="note">ความน่าจะเป็นที่จุดเดียวมีค่าเป็น 0 สนใจเฉพาะความน่าจะเป็นในช่วง</p>
+        </article>
+      </div>
+      <div class="card" style="background: rgba(232,245,233,0.6); margin-top: 1.4rem;">
+        <h3>ตารางการแจกแจง (โยนเหรียญ 2 ครั้ง)</h3>
+        <div class="table-wrapper">
+          <table class="styled" id="pmf-table">
+            <thead>
+              <tr>
+                <th>x (จำนวนหัว)</th>
+                <th>f(x) = P(X = x)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td>0</td><td>1/4</td></tr>
+              <tr><td>1</td><td>2/4</td></tr>
+              <tr><td>2</td><td>1/4</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <canvas id="pmfChart" height="220" style="margin-top: 1.2rem;"></canvas>
+      </div>
+    </section>
+
+    <section class="card" id="interactive">
+      <h2><span class="badge">Step 4</span> สำรวจ PMF ด้วยตัวเอง</h2>
+      <p>กรอกความน่าจะเป็นของตัวแปรสุ่มไม่ต่อเนื่อง (คั่นด้วยเครื่องหมายจุลภาค) ระบบจะช่วยตรวจสอบว่า PMF ถูกต้องหรือไม่</p>
+      <div class="calculator">
+        <label>ค่าที่เป็นไปได้ของ X (เช่น 0,1,2)
+          <input type="text" id="values-input" value="0,1,2" />
+        </label>
+        <label>ค่าความน่าจะเป็น f(x) (เช่น 0.25,0.5,0.25)
+          <input type="text" id="pmf-input" value="0.25,0.5,0.25" />
+        </label>
+        <button type="button" id="pmf-btn">ตรวจสอบ PMF</button>
+        <div class="result-card" id="pmf-result">ผลรวม f(x) = 1.00 ✔️</div>
+      </div>
+    </section>
+
+    <section class="card" id="examples">
+      <h2><span class="badge">Step 5</span> ตัวอย่างเพิ่มเติม</h2>
+      <div class="table-wrapper">
+        <table class="styled">
+          <thead>
+            <tr>
+              <th>ค่าของ X</th>
+              <th>f(x)</th>
+              <th>คำอธิบาย</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>0</td>
+              <td>1/4</td>
+              <td>เกิดจาก TT (ไม่มีหัวเลย)</td>
+            </tr>
+            <tr>
+              <td>1</td>
+              <td>2/4</td>
+              <td>เกิดจาก HT หรือ TH</td>
+            </tr>
+            <tr>
+              <td>2</td>
+              <td>1/4</td>
+              <td>เกิดจาก HH (ออกหัวทั้งสองครั้ง)</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <details class="toggle" open>
+        <summary>บทสรุป</summary>
+        <p>ตัวแปรสุ่มช่วยให้เราอธิบายผลลัพธ์ด้วยตัวเลข การเลือกใช้เครื่องมือ PMF หรือ PDF ขึ้นอยู่กับประเภทของตัวแปร และการตรวจสอบคุณสมบัติให้ครบถ้วนช่วยสร้างความมั่นใจในการวิเคราะห์ข้อมูล</p>
+      </details>
+    </section>
   </main>
+
+  <script>
+    const pmfChartCtx = document.getElementById('pmfChart');
+    const pmfChart = new Chart(pmfChartCtx, {
+      type: 'bar',
+      data: {
+        labels: ['0', '1', '2'],
+        datasets: [
+          {
+            label: 'f(x) = P(X = x)',
+            data: [0.25, 0.5, 0.25],
+            backgroundColor: ['#388e3c', '#66bb6a', '#81c784'],
+            borderRadius: 12
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            callbacks: {
+              label: ctx => `P(X = ${ctx.label}) = ${ctx.parsed.y.toFixed(2)}`
+            }
+          }
+        },
+        scales: {
+          y: {
+            beginAtZero: true,
+            max: 1,
+            ticks: {
+              stepSize: 0.1
+            },
+            title: {
+              display: true,
+              text: 'Probability'
+            }
+          }
+        }
+      }
+    });
+
+    const pmfButton = document.getElementById('pmf-btn');
+    const valuesInput = document.getElementById('values-input');
+    const pmfInput = document.getElementById('pmf-input');
+    const pmfResult = document.getElementById('pmf-result');
+
+    function checkPMF() {
+      const values = valuesInput.value.split(',').map(v => v.trim()).filter(Boolean);
+      const probs = pmfInput.value.split(',').map(v => Number(v.trim()));
+      if (values.length !== probs.length || !values.length) {
+        pmfResult.textContent = 'จำนวนค่าของ X ต้องเท่ากับจำนวนค่าของ f(x)';
+        return;
+      }
+      if (probs.some(p => p < 0 || !Number.isFinite(p))) {
+        pmfResult.textContent = 'ค่าความน่าจะเป็นต้องเป็นจำนวนที่ไม่ติดลบ';
+        return;
+      }
+      const total = probs.reduce((sum, p) => sum + p, 0);
+      const isValid = Math.abs(total - 1) < 1e-6;
+      pmfResult.textContent = `ผลรวม f(x) = ${total.toFixed(4)} ${isValid ? '✔️' : '❌ (ควรเท่ากับ 1)'}`;
+
+      pmfChart.data.labels = values;
+      pmfChart.data.datasets[0].data = probs;
+      pmfChart.update();
+    }
+
+    pmfButton.addEventListener('click', checkPMF);
+    checkPMF();
+  </script>
 </body>
 </html>

--- a/prob & Stats/content/06-expectation-variance.html
+++ b/prob & Stats/content/06-expectation-variance.html
@@ -2,13 +2,520 @@
 <html lang="th">
 <head>
   <meta charset="utf-8" />
-  <title>บทที่ 6: ความคาดหวังและความแปรปรวน</title>
+  <title>บทที่ 6: ค่าคาดหวังและความแปรปรวน</title>
   <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body.page {
+      min-height: 100vh;
+      background: radial-gradient(circle at 15% 15%, rgba(209,196,233,0.55), transparent 60%),
+                  radial-gradient(circle at 85% 20%, rgba(179,157,219,0.55), transparent 65%),
+                  linear-gradient(180deg, rgba(237,231,246,0.9), rgba(232,234,246,0.9));
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+    }
+    main.container {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: clamp(2rem, 5vw, 3.5rem);
+    }
+    header.hero {
+      background: linear-gradient(135deg, #5e35b1, #7e57c2);
+      color: #fff;
+      padding: clamp(2.8rem, 6vw, 4rem);
+      border-radius: 32px;
+      position: relative;
+      overflow: hidden;
+      box-shadow: 0 30px 54px rgba(94,53,177,0.28);
+      margin-bottom: 2.4rem;
+    }
+    header.hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 78% 15%, rgba(255,255,255,0.4), transparent 60%),
+                  radial-gradient(circle at 20% 70%, rgba(255,255,255,0.22), transparent 70%);
+    }
+    header.hero h1 {
+      font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem);
+      margin-bottom: 0.75rem;
+    }
+    header.hero p {
+      font-size: 1.1rem;
+      max-width: 720px;
+      line-height: 1.7;
+    }
+    section.card {
+      background: rgba(255,255,255,0.93);
+      border-radius: 26px;
+      padding: clamp(1.7rem, 4vw, 2.7rem);
+      margin-bottom: 2.2rem;
+      box-shadow: 0 20px 36px rgba(81,45,168,0.15);
+      backdrop-filter: blur(6px);
+    }
+    section.card h2 {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      color: #4527a0;
+      font-size: 2rem;
+      margin-bottom: 1rem;
+    }
+    .badge {
+      border-radius: 999px;
+      padding: 0.15rem 0.85rem;
+      background: rgba(209,196,233,0.7);
+      color: #311b92;
+      font-weight: 600;
+    }
+    .grid {
+      display: grid;
+      gap: 1.4rem;
+    }
+    @media (min-width: 920px) {
+      .grid.two { grid-template-columns: repeat(2, minmax(0,1fr)); }
+      .grid.three { grid-template-columns: repeat(3, minmax(0,1fr)); }
+    }
+    article.definition {
+      border-radius: 20px;
+      padding: 1.4rem 1.6rem;
+      background: linear-gradient(155deg, rgba(209,196,233,0.6), rgba(237,231,246,0.8));
+      border: 1px solid rgba(94,53,177,0.18);
+      display: grid;
+      gap: 0.7rem;
+    }
+    article.definition strong {
+      font-size: 1.1rem;
+      color: #4527a0;
+    }
+    .highlight {
+      border-left: 6px solid #673ab7;
+      padding: 1rem 1.25rem;
+      background: rgba(103,58,183,0.12);
+      border-radius: 18px;
+    }
+    .note {
+      color: #4527a0;
+      font-size: 0.95rem;
+    }
+    .code-box {
+      background: #1c1730;
+      color: #d1c4e9;
+      padding: 1rem 1.2rem;
+      border-radius: 14px;
+      font-family: "Fira Code", "Consolas", monospace;
+      font-size: 0.95rem;
+      overflow-x: auto;
+    }
+    .calculator {
+      display: grid;
+      gap: 1rem;
+      margin-top: 1.1rem;
+    }
+    .calculator label {
+      font-weight: 600;
+      color: #311b92;
+    }
+    .calculator input,
+    .calculator textarea,
+    .calculator select {
+      border-radius: 14px;
+      border: 1px solid rgba(94,53,177,0.3);
+      padding: 0.7rem 0.9rem;
+      font-size: 1rem;
+      background: rgba(247,245,255,0.9);
+    }
+    .calculator textarea {
+      min-height: 80px;
+      resize: vertical;
+    }
+    .calculator button {
+      border: none;
+      border-radius: 999px;
+      padding: 0.8rem 1.8rem;
+      background: linear-gradient(130deg, #5e35b1, #9575cd);
+      color: #f3e5f5;
+      font-weight: 600;
+      cursor: pointer;
+      justify-self: flex-start;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .calculator button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 28px rgba(94,53,177,0.32);
+    }
+    .result-card {
+      border-radius: 18px;
+      background: rgba(103,58,183,0.12);
+      color: #311b92;
+      padding: 1.1rem 1.3rem;
+      font-weight: 600;
+      display: grid;
+      gap: 0.35rem;
+    }
+    .table-wrapper {
+      overflow-x: auto;
+      border-radius: 16px;
+      border: 1px solid rgba(94,53,177,0.18);
+    }
+    table.styled {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 480px;
+    }
+    table.styled th,
+    table.styled td {
+      padding: 0.85rem 1.1rem;
+      text-align: left;
+    }
+    table.styled thead {
+      background: rgba(209,196,233,0.6);
+      color: #311b92;
+    }
+    table.styled tbody tr:nth-child(even) {
+      background: rgba(237,231,246,0.6);
+    }
+    .pill-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.65rem;
+    }
+    .pill {
+      padding: 0.35rem 0.9rem;
+      background: rgba(179,157,219,0.45);
+      border-radius: 999px;
+      color: #311b92;
+      font-weight: 600;
+      font-size: 0.9rem;
+    }
+    details.toggle {
+      background: rgba(209,196,233,0.45);
+      border-radius: 18px;
+      padding: 1rem 1.1rem;
+      border: 1px solid rgba(179,157,219,0.5);
+    }
+    details.toggle summary {
+      cursor: pointer;
+      font-weight: 600;
+      color: #4527a0;
+    }
+    canvas {
+      max-width: 100%;
+    }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="page">
   <main class="container">
-    <h1>บทที่ 6: ความคาดหวังและความแปรปรวน</h1>
-    <p>ส่วนนี้เตรียมไว้สำหรับเนื้อหาฉบับเต็มของบทเรียน 6. เพิ่มตัวอย่างและกรณีศึกษาได้ตามต้องการ.</p>
+    <header class="hero">
+      <h1>บทเรียนที่ 6: ค่าคาดหวังและความแปรปรวน</h1>
+      <p>สรุปสาระของการแจกแจงความน่าจะเป็นผ่านตัวเลขสำคัญสองค่า: <strong>ค่าคาดหวัง</strong> ที่บอกจุดศูนย์กลาง และ <strong>ความแปรปรวน</strong> ที่บอกการกระจายตัวของค่ารอบๆ ค่าเฉลี่ย พร้อมเครื่องมือคำนวณและกราฟโต้ตอบเพื่อเห็นภาพอย่างชัดเจน</p>
+    </header>
+
+    <section class="card" id="summary">
+      <h2><span class="badge">Step 1</span> ค่าสรุปย่อที่สำคัญ</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>ค่าคาดหวัง (Expected Value)</strong>
+          <p>ค่าเฉลี่ยถ่วงน้ำหนักด้วยความน่าจะเป็น บอกตำแหน่งที่เราคาดว่าจะพบค่าโดยเฉลี่ยหากทดลองซ้ำจำนวนมาก</p>
+          <div class="highlight">
+            <ul>
+              <li>สัญลักษณ์: <strong>E(X)</strong> หรือ <strong>μ</strong></li>
+              <li>สำหรับตัวแปรไม่ต่อเนื่อง: E(X) = ∑ x·f(x)</li>
+              <li>สำหรับตัวแปรต่อเนื่อง: E(X) = ∫ x·f(x) dx</li>
+            </ul>
+          </div>
+        </article>
+        <article class="definition">
+          <strong>ความแปรปรวน (Variance)</strong>
+          <p>วัดว่าค่าของตัวแปรสุ่มกระจายตัวไกลจากค่าเฉลี่ยมากน้อยเพียงใด ยิ่งมากยิ่งผันผวน</p>
+          <div class="highlight">
+            <ul>
+              <li>สัญลักษณ์: <strong>V(X)</strong> หรือ <strong>σ²</strong></li>
+              <li>นิยาม: V(X) = E[(X−μ)²]</li>
+              <li>สูตรคำนวณ: V(X) = E(X²) − [E(X)]²</li>
+              <li>ส่วนเบี่ยงเบนมาตรฐาน: σ = √V(X)</li>
+            </ul>
+          </div>
+        </article>
+      </div>
+      <div class="pill-list" style="margin-top:1.4rem;">
+        <span class="pill">E(X) บอก <strong>ตำแหน่ง</strong></span>
+        <span class="pill">V(X) บอก <strong>ความกว้าง</strong></span>
+        <span class="pill">σ อยู่ในหน่วยเดียวกับ X</span>
+      </div>
+    </section>
+
+    <section class="card" id="formulas">
+      <h2><span class="badge">Step 2</span> สูตรสำคัญที่ต้องจำ</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>ตัวแปรไม่ต่อเนื่อง</strong>
+          <div class="code-box">E(X) = \sum x f(x)\nE(X^2) = \sum x^2 f(x)\nV(X) = E(X^2) - [E(X)]^2</div>
+          <p class="note">ใช้ผลรวมของค่าที่เป็นไปได้ทุกค่า คูณกับความน่าจะเป็นของแต่ละค่าก่อนรวมกัน</p>
+        </article>
+        <article class="definition">
+          <strong>ตัวแปรต่อเนื่อง</strong>
+          <div class="code-box">E(X) = \int_{-\infty}^{\infty} x f(x) dx\nV(X) = \int (x-\mu)^2 f(x) dx</div>
+          <p class="note">เปลี่ยนเครื่องหมาย ∑ เป็น ∫ และมองความน่าจะเป็นเป็น "พื้นที่ใต้กราฟ"</p>
+        </article>
+      </div>
+      <details class="toggle" style="margin-top:1.2rem;">
+        <summary>เคล็ดลับ: ใช้สูตรลัด V(X) = E(X²) - [E(X)]²</summary>
+        <p>ขั้นตอน: (1) คำนวณ E(X) ตามปกติ (2) คำนวณ E(X²) โดยยกกำลังสองค่าก่อนคูณความน่าจะเป็น (3) นำ E(X²) − [E(X)]² จะได้ความแปรปรวนทันที ช่วยลดการคำนวณแบบยาวๆ ได้มาก</p>
+      </details>
+    </section>
+
+    <section class="card" id="calculator">
+      <h2><span class="badge">Step 3</span> เครื่องคิดเลขค่าคาดหวัง + ความแปรปรวน</h2>
+      <p>ป้อนค่าที่เป็นไปได้ของตัวแปรสุ่ม (x) และความน่าจะเป็น f(x) ในรูปแบบคั่นด้วยเครื่องหมายจุลภาค ระบบจะช่วยตรวจสอบว่า PMF ถูกต้องหรือไม่ พร้อมสรุป E(X), E(X²), V(X) และ σ</p>
+      <div class="calculator">
+        <label for="preset">เลือกสถานการณ์ตัวอย่าง</label>
+        <select id="preset">
+          <option value="">-- เลือก --</option>
+          <option value="coin2">โยนเหรียญ 2 ครั้ง (X = จำนวนหัว)</option>
+          <option value="game">เกมเหรียญ 1 อัน (ได้ 10 / เสีย 5)</option>
+          <option value="dice">ทอดลูกเต๋า (X = แต้ม)</option>
+        </select>
+        <label for="x-values">ค่า x (คั่นด้วย , )</label>
+        <textarea id="x-values" placeholder="เช่น 0,1,2"></textarea>
+        <label for="p-values">ความน่าจะเป็น f(x) (คั่นด้วย , )</label>
+        <textarea id="p-values" placeholder="เช่น 0.25,0.5,0.25"></textarea>
+        <button id="calc-btn">คำนวณค่าคาดหวังและความแปรปรวน</button>
+      </div>
+      <div id="calc-message" class="result-card" style="display:none; margin-top:1.2rem;"></div>
+      <div class="table-wrapper" style="margin-top:1.2rem; display:none;" id="calc-table-wrapper">
+        <table class="styled" id="calc-table">
+          <thead>
+            <tr><th>x</th><th>f(x)</th><th>x·f(x)</th><th>x²·f(x)</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <canvas id="pmf-chart" height="220" style="margin-top:1.8rem;"></canvas>
+    </section>
+
+    <section class="card" id="interpretation">
+      <h2><span class="badge">Step 4</span> ทำไมความแปรปรวนถึงสำคัญ?</h2>
+      <p>กราฟด้านล่างแสดงการเปรียบเทียบการแจกแจงสองชุดที่มีค่าเฉลี่ยเท่ากัน (μ = 5) แต่มีความแปรปรวนต่างกัน ปรับตัวเลื่อนเพื่อเห็นว่าการกระจายตัวเปลี่ยนไปอย่างไร</p>
+      <label for="variance-slider" style="font-weight:600; color:#311b92;">ปรับความแปรปรวนของกราฟสีชมพู: <span id="variance-value">2.0</span></label>
+      <input type="range" id="variance-slider" min="0.5" max="5" step="0.1" value="2" style="width:100%;" />
+      <canvas id="variance-chart" height="280" style="margin-top:1.4rem;"></canvas>
+      <div class="highlight" style="margin-top:1.4rem;">
+        <ul>
+          <li>กราฟสีม่วงอ่อน (σ² = 1) มีเส้นสูงชัน บ่งบอกค่าที่เกาะกลุ่ม</li>
+          <li>เมื่อเพิ่มความแปรปรวน กราฟจะเตี้ยและกว้างขึ้น แสดงค่าที่กระจายห่างออกไป</li>
+          <li>ส่วนเบี่ยงเบนมาตรฐาน (σ) คือรากที่สองของความแปรปรวน ทำให้ตีความได้ในหน่วยเดียวกับตัวแปร</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="card" id="examples">
+      <h2><span class="badge">Step 5</span> ตัวอย่างสรุป</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>เกมโยนเหรียญ (ได้ 10 / เสีย 5)</strong>
+          <p>ใช้สูตร E(X) = ∑ x·f(x)</p>
+          <div class="code-box">E(X) = (10)(0.5) + (-5)(0.5) = 2.5\nE(X^2) = 100(0.5) + 25(0.5) = 62.5\nV(X) = 62.5 - 2.5^2 = 56.25</div>
+          <p class="note">ค่าเฉลี่ยบวก (กำไรเฉลี่ย 2.5) แต่ความแปรปรวนสูง แปลว่าความเสี่ยงต่อครั้งยังคงมาก</p>
+        </article>
+        <article class="definition">
+          <strong>โยนเหรียญ 2 ครั้ง (X = จำนวนหัว)</strong>
+          <div class="code-box">f(0)=1/4, f(1)=2/4, f(2)=1/4\nE(X) = 1\nE(X^2) = 1.5\nV(X) = 1.5 - 1^2 = 0.5</div>
+          <p class="note">ส่วนเบี่ยงเบนมาตรฐาน ≈ 0.707 หมายถึงค่าจะอยู่ใกล้ 1 ส่วนใหญ่</p>
+        </article>
+      </div>
+      <details class="toggle" style="margin-top:1.3rem;">
+        <summary>ข้อควรระวัง</summary>
+        <ul>
+          <li>PMF ต้องรวมกันได้ 1 เสมอ หากไม่ครบให้ปรับหรือเช็กการปัดเศษ</li>
+          <li>ค่าคาดหวังไม่จำเป็นต้องเป็นค่าที่เกิดขึ้นจริง (เช่น 3.5 จากลูกเต๋า)</li>
+          <li>ความแปรปรวนไม่เคยติดลบ เพราะเป็นผลรวมของกำลังสอง</li>
+        </ul>
+      </details>
+    </section>
   </main>
+
+  <script>
+    const presetSelect = document.getElementById('preset');
+    const xInput = document.getElementById('x-values');
+    const pInput = document.getElementById('p-values');
+    const calcBtn = document.getElementById('calc-btn');
+    const messageEl = document.getElementById('calc-message');
+    const tableWrapper = document.getElementById('calc-table-wrapper');
+    const tableBody = document.querySelector('#calc-table tbody');
+    let pmfChart;
+
+    const presets = {
+      coin2: {
+        x: ['0', '1', '2'],
+        p: ['0.25', '0.5', '0.25']
+      },
+      game: {
+        x: ['10', '-5'],
+        p: ['0.5', '0.5']
+      },
+      dice: {
+        x: ['1','2','3','4','5','6'],
+        p: ['0.1667','0.1667','0.1667','0.1667','0.1667','0.1667']
+      }
+    };
+
+    presetSelect.addEventListener('change', () => {
+      const option = presets[presetSelect.value];
+      if (!option) return;
+      xInput.value = option.x.join(',');
+      pInput.value = option.p.join(',');
+    });
+
+    function formatNumber(num) {
+      return Number.isFinite(num) ? Number(num.toFixed(6)).toString() : 'NaN';
+    }
+
+    calcBtn.addEventListener('click', () => {
+      const xs = xInput.value.split(',').map(v => v.trim()).filter(Boolean).map(Number);
+      const ps = pInput.value.split(',').map(v => v.trim()).filter(Boolean).map(Number);
+
+      if (!xs.length || xs.length !== ps.length) {
+        showMessage('กรุณากรอกค่า x และ f(x) ให้ครบถ้วน และมีจำนวนเท่ากัน', true);
+        return;
+      }
+
+      if (ps.some(p => p < 0 || !Number.isFinite(p))) {
+        showMessage('ความน่าจะเป็นต้องเป็นตัวเลขที่ไม่ติดลบ', true);
+        return;
+      }
+
+      const sumP = ps.reduce((acc, cur) => acc + cur, 0);
+      if (Math.abs(sumP - 1) > 1e-4) {
+        showMessage(`คำเตือน: ผลรวมของความน่าจะเป็น = ${formatNumber(sumP)} (ไม่เท่ากับ 1)`, true);
+      } else {
+        showMessage('PMF ถูกต้อง! ผลรวมของ f(x) = 1', false);
+      }
+
+      tableBody.innerHTML = '';
+      let ex = 0;
+      let ex2 = 0;
+      xs.forEach((x, idx) => {
+        const p = ps[idx];
+        const xp = x * p;
+        const x2p = x * x * p;
+        ex += xp;
+        ex2 += x2p;
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${x}</td><td>${formatNumber(p)}</td><td>${formatNumber(xp)}</td><td>${formatNumber(x2p)}</td>`;
+        tableBody.appendChild(tr);
+      });
+      const variance = ex2 - ex * ex;
+      const sd = Math.sqrt(Math.max(variance, 0));
+      const summaryHtml = `E(X) = <strong>${formatNumber(ex)}</strong> | E(X^2) = <strong>${formatNumber(ex2)}</strong> | V(X) = <strong>${formatNumber(variance)}</strong> | σ = <strong>${formatNumber(sd)}</strong>`;
+      messageEl.innerHTML = summaryHtml;
+      messageEl.style.display = 'grid';
+      tableWrapper.style.display = 'block';
+      renderPMFChart(xs, ps);
+    });
+
+    function showMessage(msg, isWarn) {
+      messageEl.innerHTML = msg;
+      messageEl.style.display = 'grid';
+      messageEl.style.background = isWarn ? 'rgba(244,143,177,0.22)' : 'rgba(103,58,183,0.12)';
+      messageEl.style.color = isWarn ? '#ad1457' : '#311b92';
+    }
+
+    function renderPMFChart(xs, ps) {
+      const ctx = document.getElementById('pmf-chart');
+      if (pmfChart) pmfChart.destroy();
+      pmfChart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: xs,
+          datasets: [{
+            label: 'f(x)',
+            data: ps,
+            backgroundColor: 'rgba(126,87,194,0.6)',
+            borderColor: '#5e35b1',
+            borderWidth: 1.5,
+            borderRadius: 12
+          }]
+        },
+        options: {
+          plugins: {
+            legend: { display: false }
+          },
+          scales: {
+            y: {
+              beginAtZero: true,
+              title: { display: true, text: 'Probability', color: '#4527a0' }
+            }
+          }
+        }
+      });
+    }
+
+    // Variance chart for normal curves
+    const varianceCtx = document.getElementById('variance-chart');
+    const varianceSlider = document.getElementById('variance-slider');
+    const varianceValue = document.getElementById('variance-value');
+
+    function normalPdf(x, mean, variance) {
+      const sd = Math.sqrt(variance);
+      const coeff = 1 / (sd * Math.sqrt(2 * Math.PI));
+      return coeff * Math.exp(-0.5 * ((x - mean) / sd) ** 2);
+    }
+
+    const xDomain = Array.from({ length: 121 }, (_, idx) => 0 + idx * 0.1);
+    const baseData = xDomain.map(x => normalPdf(x, 5, 1));
+
+    const varianceChart = new Chart(varianceCtx, {
+      type: 'line',
+      data: {
+        labels: xDomain,
+        datasets: [
+          {
+            label: 'σ² = 1',
+            data: baseData,
+            borderColor: '#5e35b1',
+            backgroundColor: 'rgba(94,53,177,0.18)',
+            borderWidth: 2,
+            tension: 0.25,
+            fill: true
+          },
+          {
+            label: 'σ² ปรับค่า',
+            data: xDomain.map(x => normalPdf(x, 5, parseFloat(varianceSlider.value))),
+            borderColor: '#ec407a',
+            backgroundColor: 'rgba(236,64,122,0.18)',
+            borderWidth: 2,
+            tension: 0.25,
+            fill: true
+          }
+        ]
+      },
+      options: {
+        plugins: {
+          legend: {
+            labels: { color: '#311b92' }
+          }
+        },
+        scales: {
+          x: {
+            title: { display: true, text: 'ค่า X', color: '#311b92' }
+          },
+          y: {
+            title: { display: true, text: 'ความหนาแน่น (PDF)', color: '#311b92' },
+            beginAtZero: true
+          }
+        }
+      }
+    });
+
+    varianceSlider.addEventListener('input', () => {
+      const variance = parseFloat(varianceSlider.value);
+      varianceValue.textContent = variance.toFixed(1);
+      varianceChart.data.datasets[1].data = xDomain.map(x => normalPdf(x, 5, variance));
+      varianceChart.update();
+    });
+  </script>
 </body>
 </html>

--- a/prob & Stats/content/07-discrete-uniform.html
+++ b/prob & Stats/content/07-discrete-uniform.html
@@ -2,13 +2,337 @@
 <html lang="th">
 <head>
   <meta charset="utf-8" />
-  <title>บทที่ 7: การแจกแจงไม่ต่อเนื่อง</title>
+  <title>บทที่ 7: การแจกแจงเอกรูปไม่ต่อเนื่อง</title>
   <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      min-height: 100vh;
+      background: linear-gradient(140deg, rgba(224,247,250,0.9), rgba(232,245,253,0.92));
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+    }
+    main.container {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: clamp(2rem, 5vw, 3.6rem);
+    }
+    header.hero {
+      background: linear-gradient(135deg, #00838f, #00acc1);
+      color: #fff;
+      padding: clamp(2.7rem, 6vw, 3.8rem);
+      border-radius: 32px;
+      position: relative;
+      overflow: hidden;
+      margin-bottom: 2.4rem;
+      box-shadow: 0 28px 48px rgba(0,131,143,0.28);
+    }
+    header.hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 82% 20%, rgba(255,255,255,0.35), transparent 60%),
+                  radial-gradient(circle at 18% 70%, rgba(255,255,255,0.25), transparent 70%);
+    }
+    header.hero h1 {
+      font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem);
+      margin-bottom: 0.75rem;
+    }
+    header.hero p {
+      font-size: 1.12rem;
+      max-width: 720px;
+      line-height: 1.7;
+    }
+    section.card {
+      background: rgba(255,255,255,0.95);
+      border-radius: 26px;
+      padding: clamp(1.7rem, 4vw, 2.7rem);
+      margin-bottom: 2.1rem;
+      box-shadow: 0 20px 34px rgba(0,121,128,0.18);
+    }
+    h2 {
+      display: flex;
+      align-items: center;
+      gap: 0.7rem;
+      font-size: 1.95rem;
+      color: #006064;
+    }
+    .badge {
+      background: rgba(178,235,242,0.8);
+      border-radius: 999px;
+      padding: 0.18rem 0.9rem;
+      color: #004d40;
+      font-weight: 600;
+      font-size: 0.92rem;
+    }
+    .grid {
+      display: grid;
+      gap: 1.4rem;
+    }
+    @media (min-width: 900px) {
+      .grid.two { grid-template-columns: repeat(2, minmax(0,1fr)); }
+      .grid.three { grid-template-columns: repeat(3, minmax(0,1fr)); }
+    }
+    article.definition {
+      border-radius: 20px;
+      background: linear-gradient(160deg, rgba(178,235,242,0.55), rgba(224,247,250,0.65));
+      border: 1px solid rgba(0,121,107,0.2);
+      padding: 1.35rem 1.5rem;
+      display: grid;
+      gap: 0.7rem;
+    }
+    article.definition strong { color: #006064; font-size: 1.08rem; }
+    .highlight {
+      border-left: 6px solid #0097a7;
+      background: rgba(0,151,167,0.12);
+      border-radius: 18px;
+      padding: 1rem 1.2rem;
+    }
+    .code-box {
+      background: #00363a;
+      color: #b2ebf2;
+      padding: 1rem 1.2rem;
+      border-radius: 14px;
+      font-family: "Fira Code", "Consolas", monospace;
+      font-size: 0.95rem;
+      overflow-x: auto;
+    }
+    .note { color: #006064; font-size: 0.95rem; }
+    .calculator { display: grid; gap: 1rem; margin-top: 1.1rem; }
+    .calculator label { font-weight: 600; color: #004d40; }
+    .calculator input,
+    .calculator select {
+      border-radius: 14px;
+      border: 1px solid rgba(0,121,107,0.35);
+      padding: 0.65rem 0.85rem;
+      font-size: 1rem;
+      background: rgba(240,255,255,0.9);
+    }
+    .calculator button {
+      border: none;
+      border-radius: 999px;
+      padding: 0.75rem 1.8rem;
+      background: linear-gradient(135deg, #00838f, #00acc1);
+      color: #e0f7fa;
+      font-weight: 600;
+      cursor: pointer;
+      justify-self: flex-start;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .calculator button:hover { transform: translateY(-1px); box-shadow: 0 12px 24px rgba(0,131,143,0.32); }
+    .result-card {
+      border-radius: 18px;
+      background: rgba(0,150,136,0.12);
+      padding: 1rem 1.3rem;
+      color: #004d40;
+      font-weight: 600;
+      display: none;
+      gap: 0.35rem;
+    }
+    .pill-list { display: flex; flex-wrap: wrap; gap: 0.6rem; }
+    .pill { padding: 0.35rem 0.85rem; border-radius: 999px; background: rgba(128,222,234,0.55); color: #004d40; font-weight: 600; font-size: 0.88rem; }
+    .table-wrapper { overflow-x: auto; border-radius: 16px; border: 1px solid rgba(0,121,107,0.18); margin-top: 1.3rem; display:none; }
+    table.styled { width: 100%; border-collapse: collapse; min-width: 480px; }
+    table.styled th, table.styled td { padding: 0.85rem 1.1rem; text-align: center; }
+    table.styled thead { background: rgba(178,235,242,0.6); color: #004d40; }
+    table.styled tbody tr:nth-child(even) { background: rgba(224,247,250,0.6); }
+    details.toggle { background: rgba(178,235,242,0.45); border-radius: 18px; padding: 1rem 1.1rem; border: 1px solid rgba(128,222,234,0.6); }
+    details.toggle summary { cursor: pointer; font-weight: 600; color: #006064; }
+    canvas { max-width: 100%; }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="page">
   <main class="container">
-    <h1>บทที่ 7: การแจกแจงไม่ต่อเนื่อง</h1>
-    <p>ส่วนนี้เตรียมไว้สำหรับเนื้อหาฉบับเต็มของบทเรียน 7. เพิ่มตัวอย่างและกรณีศึกษาได้ตามต้องการ.</p>
+    <header class="hero">
+      <h1>บทเรียนที่ 7: การแจกแจงเอกรูปไม่ต่อเนื่อง (Discrete Uniform)</h1>
+      <p>เรียนรู้การแจกแจงที่ "ยุติธรรม" ที่สุด ทุกค่ามีโอกาสเท่ากัน ไม่ว่าจะสุ่มตัวเลขจากลูกเต๋า ไพ่ หรือเลขที่จับสลาก พร้อมสูตรลัดและกราฟโต้ตอบให้เห็นภาพแบบชัดเจน</p>
+    </header>
+
+    <section class="card" id="concept">
+      <h2><span class="badge">Concept</span> ทุกผลลัพธ์มีสิทธิ์เท่ากัน</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>นิยาม</strong>
+          <p>ตัวแปรสุ่ม X ที่มีค่าเป็น {1, 2, …, k} โดยที่ความน่าจะเป็นของทุกค่าคือ 1/k เรียกว่า <em>การแจกแจงเอกรูปไม่ต่อเนื่อง</em> (Discrete Uniform)</p>
+          <div class="highlight">
+            <ul>
+              <li>ใช้ได้เมื่อสุ่ม <strong>โดยยุติธรรม</strong> ทุกค่าเกิดได้เท่ากัน</li>
+              <li>เช่น ลูกเต๋า, การหยิบไพ่ 1 ใบ, การสุ่มหมายเลข</li>
+            </ul>
+          </div>
+        </article>
+        <article class="definition">
+          <strong>สถานการณ์ที่พบบ่อย</strong>
+          <ul>
+            <li>สุ่มตัวเลขจาก 1 ถึง n โดยไม่โน้มเอียง</li>
+            <li>สุ่มรหัสผ่านตัวเลข 0-9 (เลือก 1 ตัว)</li>
+            <li>สุ่มชื่อจากรายชื่อที่จัดเรียงแบบอัตโนมัติ</li>
+          </ul>
+          <div class="pill-list">
+            <span class="pill">Fair</span>
+            <span class="pill">ทุกคนมีสิทธิ์</span>
+            <span class="pill">โอกาสคงที่</span>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="card" id="formulas">
+      <h2><span class="badge">Formulas</span> สูตรหลักจำให้ขึ้นใจ</h2>
+      <div class="grid three">
+        <article class="definition">
+          <strong>ฟังก์ชันมวลความน่าจะเป็น (PMF)</strong>
+          <div class="code-box">f(x) = P(X = x) = \frac{1}{k}\nสำหรับ x = 1,2,...,k</div>
+          <p class="note">ทุกแท่งในกราฟสูงเท่ากัน</p>
+        </article>
+        <article class="definition">
+          <strong>ค่าคาดหวัง</strong>
+          <div class="code-box">E(X) = \frac{k + 1}{2}</div>
+          <p class="note">ค่าเฉลี่ยคือกึ่งกลางของช่วง</p>
+        </article>
+        <article class="definition">
+          <strong>ความแปรปรวน</strong>
+          <div class="code-box">V(X) = \frac{k^2 - 1}{12}</div>
+          <p class="note">ขึ้นกับจำนวนผลลัพธ์ทั้งหมด</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="card" id="interactive">
+      <h2><span class="badge">Playground</span> ปรับ k แล้วดูความเปลี่ยนแปลง</h2>
+      <div class="calculator">
+        <label for="k-slider">จำนวนผลลัพธ์ทั้งหมด (k): <strong id="k-value">6</strong></label>
+        <input type="range" id="k-slider" min="2" max="20" value="6" />
+        <label for="range-start">หาความน่าจะเป็นที่ X อยู่ระหว่าง</label>
+        <div style="display:grid; gap:0.7rem; grid-template-columns: repeat(auto-fit, minmax(120px,1fr));">
+          <input type="number" id="range-start" value="3" min="1" />
+          <input type="number" id="range-end" value="5" min="1" />
+        </div>
+        <button id="prob-btn">คำนวณความน่าจะเป็นในช่วง</button>
+      </div>
+      <div id="summary-card" class="result-card" style="display:grid; margin-top:1.2rem;"></div>
+      <div id="prob-card" class="result-card" style="margin-top:0.9rem;"></div>
+      <div class="table-wrapper" id="pmf-table-wrapper">
+        <table class="styled" id="pmf-table">
+          <thead><tr><th>x</th><th>f(x)</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <canvas id="pmf-chart" height="240" style="margin-top:1.5rem;"></canvas>
+    </section>
+
+    <section class="card" id="example">
+      <h2><span class="badge">Example</span> ทอดลูกเต๋า 1 ลูก</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>ให้ X = แต้มบนหน้าลูกเต๋า</strong>
+          <div class="code-box">f(x) = 1/6 สำหรับ x = 1,...,6\nE(X) = (6+1)/2 = 3.5\nV(X) = (6^2 - 1)/12 = 35/12</div>
+          <p class="note">ค่าเฉลี่ย 3.5 แม้จะไม่มีหน้าไหนเป็น 3.5 จริงๆ</p>
+        </article>
+        <article class="definition">
+          <strong>คำถามน่าสนใจ</strong>
+          <ul>
+            <li>P(แต้มเป็นเลขคู่) = 3 × (1/6) = 0.5</li>
+            <li>P(แต้ม ≥ 4) = 3 × (1/6) = 0.5</li>
+            <li>ความแปรปรวนสูงขึ้นหากเพิ่มจำนวนหน้าของลูกเต๋า</li>
+          </ul>
+          <div class="highlight">
+            <p>การแจกแจงเอกรูปไม่ต่อเนื่องเป็นฐานของการคำนวณความน่าจะเป็นพื้นฐานจำนวนมาก เช่น การสุ่มรหัสหรือการเลือกคนแบบเท่าเทียม</p>
+          </div>
+        </article>
+      </div>
+      <details class="toggle" style="margin-top:1.2rem;">
+        <summary>ข้อควรจำ</summary>
+        <ul>
+          <li>หากข้อมูลไม่ได้ยุติธรรม (เช่น ลูกเต๋าเบี้ยว) จะไม่ใช่การแจกแจงเอกรูป</li>
+          <li>ใช้ได้กับค่าที่แตกต่างกันแต่มีโอกาสเท่ากัน ไม่จำเป็นต้องเริ่มที่ 1 (สามารถปรับ shift ได้)</li>
+          <li>เมื่อ k ใหญ่ขึ้น ค่าเฉลี่ยขยับไปกลางช่วงและความแปรปรวนเพิ่มตามสูตร</li>
+        </ul>
+      </details>
+    </section>
   </main>
+
+  <script>
+    const kSlider = document.getElementById('k-slider');
+    const kValue = document.getElementById('k-value');
+    const summaryCard = document.getElementById('summary-card');
+    const probCard = document.getElementById('prob-card');
+    const pmfTableBody = document.querySelector('#pmf-table tbody');
+    const rangeStart = document.getElementById('range-start');
+    const rangeEnd = document.getElementById('range-end');
+    const probBtn = document.getElementById('prob-btn');
+    let pmfChart;
+
+    function updateUniform(k) {
+      kValue.textContent = k;
+      const pmf = 1 / k;
+      summaryCard.style.display = 'grid';
+      summaryCard.innerHTML = `f(x) = 1/${k} = ${pmf.toFixed(4)} | E(X) = ${( (k + 1) / 2 ).toFixed(2)} | V(X) = ${(((k * k) - 1) / 12).toFixed(4)}`;
+
+      pmfTableBody.innerHTML = '';
+      const labels = [];
+      const data = [];
+      for (let i = 1; i <= k; i += 1) {
+        labels.push(i);
+        data.push(pmf);
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${i}</td><td>${pmf.toFixed(4)}</td>`;
+        pmfTableBody.appendChild(tr);
+      }
+      document.getElementById('pmf-table-wrapper').style.display = 'block';
+      renderChart(labels, data);
+    }
+
+    function renderChart(labels, data) {
+      const ctx = document.getElementById('pmf-chart');
+      if (pmfChart) pmfChart.destroy();
+      pmfChart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [{
+            label: 'f(x)',
+            data,
+            backgroundColor: 'rgba(0,188,212,0.5)',
+            borderColor: '#00838f',
+            borderWidth: 1.5,
+            borderRadius: 12
+          }]
+        },
+        options: {
+          plugins: { legend: { display: false } },
+          scales: {
+            x: { title: { display: true, text: 'ค่า x', color: '#006064' } },
+            y: {
+              beginAtZero: true,
+              title: { display: true, text: 'Probability', color: '#006064' }
+            }
+          }
+        }
+      });
+    }
+
+    function calculateRangeProbability() {
+      const k = parseInt(kSlider.value, 10);
+      const start = Math.max(1, Math.min(parseInt(rangeStart.value, 10) || 1, k));
+      const end = Math.max(start, Math.min(parseInt(rangeEnd.value, 10) || k, k));
+      rangeStart.value = start;
+      rangeEnd.value = end;
+      const count = end - start + 1;
+      const probability = count / k;
+      probCard.style.display = 'grid';
+      probCard.innerHTML = `P(${start} \u2264 X \u2264 ${end}) = ${count}/${k} = ${probability.toFixed(4)}`;
+    }
+
+    kSlider.addEventListener('input', () => {
+      updateUniform(parseInt(kSlider.value, 10));
+      calculateRangeProbability();
+    });
+
+    probBtn.addEventListener('click', calculateRangeProbability);
+
+    updateUniform(parseInt(kSlider.value, 10));
+    calculateRangeProbability();
+  </script>
 </body>
 </html>

--- a/prob & Stats/content/08-binomial.html
+++ b/prob & Stats/content/08-binomial.html
@@ -2,13 +2,342 @@
 <html lang="th">
 <head>
   <meta charset="utf-8" />
-  <title>บทที่ 8: การแจกแจงแบบทวินาม</title>
+  <title>บทที่ 8: การแจกแจงทวินาม</title>
   <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      min-height: 100vh;
+      background: linear-gradient(150deg, rgba(255,243,224,0.9), rgba(255,236,179,0.9));
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+    }
+    main.container { max-width: 1120px; margin: 0 auto; padding: clamp(2rem,5vw,3.5rem); }
+    header.hero {
+      background: linear-gradient(135deg, #ff8f00, #ffa726);
+      color: #fff;
+      padding: clamp(2.8rem,6vw,4rem);
+      border-radius: 32px;
+      position: relative;
+      overflow: hidden;
+      margin-bottom: 2.4rem;
+      box-shadow: 0 30px 48px rgba(255,143,0,0.28);
+    }
+    header.hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 80% 20%, rgba(255,255,255,0.4), transparent 60%),
+                  radial-gradient(circle at 20% 70%, rgba(255,255,255,0.25), transparent 70%);
+    }
+    header.hero h1 { font-size: clamp(2.5rem,3vw+1.6rem,3.7rem); margin-bottom: 0.7rem; }
+    header.hero p { font-size: 1.12rem; max-width: 760px; line-height: 1.7; }
+    section.card {
+      background: rgba(255,255,255,0.95);
+      border-radius: 26px;
+      padding: clamp(1.7rem,4vw,2.8rem);
+      margin-bottom: 2.2rem;
+      box-shadow: 0 22px 38px rgba(255,143,0,0.16);
+    }
+    h2 {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      color: #e65100;
+      font-size: 1.95rem;
+    }
+    .badge { border-radius: 999px; padding: 0.2rem 0.9rem; background: rgba(255,224,178,0.9); color: #e65100; font-weight: 600; }
+    .grid { display: grid; gap: 1.4rem; }
+    @media (min-width: 950px) { .grid.two { grid-template-columns: repeat(2, minmax(0,1fr)); } .grid.three { grid-template-columns: repeat(3, minmax(0,1fr)); } }
+    article.definition {
+      border-radius: 20px;
+      background: linear-gradient(155deg, rgba(255,224,178,0.6), rgba(255,243,224,0.75));
+      border: 1px solid rgba(230,81,0,0.2);
+      padding: 1.4rem 1.6rem;
+      display: grid;
+      gap: 0.7rem;
+    }
+    article.definition strong { font-size: 1.1rem; color: #bf360c; }
+    .highlight { border-left: 6px solid #fb8c00; background: rgba(251,140,0,0.12); border-radius: 18px; padding: 1rem 1.2rem; }
+    .code-box { background: #331b00; color: #ffe0b2; padding: 1rem 1.2rem; border-radius: 14px; font-family: "Fira Code", "Consolas", monospace; font-size: 0.95rem; overflow-x: auto; }
+    .note { color: #e65100; font-size: 0.95rem; }
+    .pill-list { display:flex; flex-wrap:wrap; gap:0.65rem; }
+    .pill { padding:0.35rem 0.85rem; border-radius:999px; background:rgba(255,204,128,0.6); color:#bf360c; font-weight:600; font-size:0.88rem; }
+    .calculator { display:grid; gap:1rem; margin-top:1.1rem; }
+    .calculator label { font-weight:600; color:#bf360c; }
+    .calculator input, .calculator select {
+      border-radius:14px;
+      border:1px solid rgba(230,81,0,0.35);
+      padding:0.65rem 0.85rem;
+      font-size:1rem;
+      background:rgba(255,253,231,0.9);
+    }
+    .calculator input[type="range"] { padding:0; }
+    .calculator button {
+      border:none;
+      border-radius:999px;
+      padding:0.75rem 1.8rem;
+      background:linear-gradient(135deg,#f57c00,#ffa726);
+      color:#fff3e0;
+      font-weight:600;
+      cursor:pointer;
+      justify-self:flex-start;
+      transition:transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .calculator button:hover { transform:translateY(-1px); box-shadow:0 12px 26px rgba(245,124,0,0.3); }
+    .result-card {
+      border-radius:18px;
+      background:rgba(255,183,77,0.18);
+      color:#e65100;
+      padding:1rem 1.3rem;
+      font-weight:600;
+      display:none;
+      gap:0.35rem;
+    }
+    .table-wrapper { overflow-x:auto; border-radius:16px; border:1px solid rgba(230,81,0,0.2); margin-top:1.3rem; display:none; }
+    table.styled { width:100%; border-collapse:collapse; min-width:520px; }
+    table.styled th, table.styled td { padding:0.85rem 1.1rem; text-align:center; }
+    table.styled thead { background:rgba(255,224,178,0.7); color:#bf360c; }
+    table.styled tbody tr:nth-child(even) { background:rgba(255,243,224,0.65); }
+    details.toggle { background:rgba(255,224,178,0.55); border-radius:18px; padding:1rem 1.1rem; border:1px solid rgba(255,183,77,0.6); }
+    details.toggle summary { cursor:pointer; font-weight:600; color:#bf360c; }
+    canvas { max-width:100%; }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="page">
   <main class="container">
-    <h1>บทที่ 8: การแจกแจงแบบทวินาม</h1>
-    <p>ส่วนนี้เตรียมไว้สำหรับเนื้อหาฉบับเต็มของบทเรียน 8. เพิ่มตัวอย่างและกรณีศึกษาได้ตามต้องการ.</p>
+    <header class="hero">
+      <h1>บทเรียนที่ 8: การแจกแจงทวินาม (Binomial Distribution)</h1>
+      <p>จับหลักของการนับจำนวนความสำเร็จจากการทดลองที่มีแค่สองผลลัพธ์: <strong>สำเร็จ</strong> หรือ <strong>ล้มเหลว</strong> พร้อมตัวอย่างจริงตั้งแต่การโยนเหรียญ การสอบ ไปจนถึงการควบคุมคุณภาพ</p>
+    </header>
+
+    <section class="card" id="setup">
+      <h2><span class="badge">Understand</span> เงื่อนไข 4 ข้อสำคัญ</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>สูตร PMF</strong>
+          <div class="code-box">P(X = x) = \binom{n}{x} p^x (1-p)^{n-x}</div>
+          <div class="highlight">
+            <ul>
+              <li>X: จำนวนความสำเร็จ</li>
+              <li>n: จำนวนครั้งทดลอง</li>
+              <li>p: โอกาสสำเร็จในแต่ละครั้ง (คงที่)</li>
+            </ul>
+          </div>
+        </article>
+        <article class="definition">
+          <strong>เช็กลิสต์การใช้</strong>
+          <div class="pill-list">
+            <span class="pill">จำนวนครั้งแน่นอน (n)</span>
+            <span class="pill">แต่ละครั้งเป็นอิสระ</span>
+            <span class="pill">ผลลัพธ์มี 2 แบบ</span>
+            <span class="pill">p คงที่ทุกครั้ง</span>
+          </div>
+          <p class="note">ถ้าเงื่อนไขขาดข้อใดข้อหนึ่ง ให้พิจารณาการแจกแจงอื่นแทน</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="card" id="stats">
+      <h2><span class="badge">Moments</span> ค่าเฉลี่ยและความแปรปรวน</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>ค่าคาดหวัง</strong>
+          <div class="code-box">E(X) = np</div>
+          <p class="note">จำนวนครั้งที่เราคาดว่าจะสำเร็จโดยเฉลี่ย</p>
+        </article>
+        <article class="definition">
+          <strong>ความแปรปรวน</strong>
+          <div class="code-box">V(X) = np(1-p)</div>
+          <p class="note">ยิ่ง p ใกล้ 0 หรือ 1 ความแปรปรวนจะลดลง</p>
+        </article>
+      </div>
+      <details class="toggle" style="margin-top:1.2rem;">
+        <summary>เหตุผลที่ต้องมี \(\binom{n}{x}\)</summary>
+        <p>เมื่อเราพูดว่ามีความสำเร็จ x ครั้ง เราไม่ได้ระบุว่ามันเกิดในรอบไหนบ้าง การเลือกว่าจะให้ความสำเร็จเกิดในรอบใดจึงมี \(\binom{n}{x}\) วิธี และแต่ละวิธีมีความน่าจะเป็นเดียวกันคือ p^x(1-p)^{n-x}</p>
+      </details>
+    </section>
+
+    <section class="card" id="playground">
+      <h2><span class="badge">Playground</span> เครื่องคิดเลขการแจกแจงทวินาม</h2>
+      <div class="calculator">
+        <label for="scenario">เลือกสถานการณ์</label>
+        <select id="scenario">
+          <option value="">-- เลือก --</option>
+          <option value="coin">โยนเหรียญ 10 ครั้ง (p=0.5)</option>
+          <option value="quiz">เดาข้อสอบ 5 ข้อ ตัวเลือก 4 ตัว (p=0.25)</option>
+          <option value="quality">ตรวจสินค้าล็อต 20 ชิ้น โอกาสชำรุด 5% (p=0.05)</option>
+        </select>
+        <label for="n-input">จำนวนครั้งทดลอง (n): <strong id="n-display">10</strong></label>
+        <input type="range" id="n-input" min="1" max="60" value="10" />
+        <label for="p-input">โอกาสสำเร็จในแต่ละครั้ง (p): <strong id="p-display">0.50</strong></label>
+        <input type="range" id="p-input" min="0" max="1" step="0.01" value="0.5" />
+        <label for="x-input">จำนวนความสำเร็จที่สนใจ (x)</label>
+        <input type="number" id="x-input" min="0" value="5" />
+        <button id="calc-btn">คำนวณความน่าจะเป็น</button>
+      </div>
+      <div id="result-card" class="result-card"></div>
+      <div class="table-wrapper" id="table-wrapper">
+        <table class="styled" id="binomial-table">
+          <thead><tr><th>x</th><th>P(X=x)</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <canvas id="binomial-chart" height="260" style="margin-top:1.4rem;"></canvas>
+    </section>
+
+    <section class="card" id="example">
+      <h2><span class="badge">Example</span> เดาข้อสอบให้ถูก 2 ข้อ</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>โจทย์</strong>
+          <p>ข้อสอบปรนัย 5 ข้อ แต่ละข้อมี 4 ตัวเลือก นักเรียนเดาอย่างเดียว อยากรู้ว่าจะเดาถูก 2 ข้อพอดี</p>
+          <div class="code-box">n = 5, p = 0.25\nP(X=2) = \binom{5}{2}(0.25)^2(0.75)^3 \approx 0.2637\nE(X) = 5 × 0.25 = 1.25\nV(X) = 5 × 0.25 × 0.75 = 0.9375</div>
+        </article>
+        <article class="definition">
+          <strong>ตีความ</strong>
+          <ul>
+            <li>โอกาสเดาถูก 2 ข้อ ≈ 26.37%</li>
+            <li>ค่าเฉลี่ย 1.25 ข้อ หมายถึงโดยเฉลี่ยจะเดาถูกแค่ประมาณ 1 ข้อ</li>
+            <li>หากเพิ่มจำนวนข้อ n หรือเปลี่ยน p กราฟจะเปลี่ยนรูปทันที</li>
+          </ul>
+          <div class="highlight">
+            <p>การแจกแจงทวินามเชื่อมโยงกับบทก่อน (Combination) โดยตรง เพราะต้องรู้จำนวนวิธีการเลือกความสำเร็จ x ครั้งจาก n ครั้ง</p>
+          </div>
+        </article>
+      </div>
+      <details class="toggle" style="margin-top:1.2rem;">
+        <summary>Tips</summary>
+        <ul>
+          <li>หาก n ใหญ่และ p ไม่เล็กหรือใหญ่เกินไป กราฟจะใกล้เคียงปกติ (Normal Approximation)</li>
+          <li>ใช้สูตรสะสม: P(X ≤ k) = ∑<sub>x=0</sub><sup>k</sup> \binom{n}{x} p^x(1-p)^{n-x}</li>
+          <li>หากทดลองโดยไม่ใส่คืนจากประชากรเล็ก ให้พิจารณาการแจกแจงไฮเปอร์จีออเมตริกแทน</li>
+        </ul>
+      </details>
+    </section>
   </main>
+
+  <script>
+    const scenarioSelect = document.getElementById('scenario');
+    const nInput = document.getElementById('n-input');
+    const pInput = document.getElementById('p-input');
+    const xInput = document.getElementById('x-input');
+    const nDisplay = document.getElementById('n-display');
+    const pDisplay = document.getElementById('p-display');
+    const calcBtn = document.getElementById('calc-btn');
+    const resultCard = document.getElementById('result-card');
+    const tableWrapper = document.getElementById('table-wrapper');
+    const tableBody = document.querySelector('#binomial-table tbody');
+    let binomialChart;
+
+    const scenarios = {
+      coin: { n: 10, p: 0.5, x: 5 },
+      quiz: { n: 5, p: 0.25, x: 2 },
+      quality: { n: 20, p: 0.05, x: 1 }
+    };
+
+    scenarioSelect.addEventListener('change', () => {
+      const data = scenarios[scenarioSelect.value];
+      if (!data) return;
+      nInput.value = data.n;
+      pInput.value = data.p;
+      xInput.value = data.x;
+      updateDisplays();
+      calculate();
+    });
+
+    function updateDisplays() {
+      const n = parseInt(nInput.value, 10);
+      const p = parseFloat(pInput.value);
+      nDisplay.textContent = n;
+      pDisplay.textContent = p.toFixed(2);
+      xInput.max = n;
+    }
+
+    function factorial(n) {
+      if (n === 0 || n === 1) return 1;
+      let result = 1;
+      for (let i = 2; i <= n; i += 1) result *= i;
+      return result;
+    }
+
+    function combination(n, k) {
+      if (k < 0 || k > n) return 0;
+      if (k === 0 || k === n) return 1;
+      k = Math.min(k, n - k);
+      let numerator = 1;
+      let denominator = 1;
+      for (let i = 1; i <= k; i += 1) {
+        numerator *= (n - (k - i));
+        denominator *= i;
+      }
+      return numerator / denominator;
+    }
+
+    function binomialProbability(n, p, x) {
+      return combination(n, x) * Math.pow(p, x) * Math.pow(1 - p, n - x);
+    }
+
+    function calculate() {
+      const n = parseInt(nInput.value, 10);
+      const p = parseFloat(pInput.value);
+      const x = Math.min(Math.max(parseInt(xInput.value, 10) || 0, 0), n);
+      xInput.value = x;
+      const probability = binomialProbability(n, p, x);
+      resultCard.style.display = 'grid';
+      resultCard.innerHTML = `P(X = ${x}) = ${probability.toFixed(6)} | E(X) = ${(n * p).toFixed(3)} | V(X) = ${(n * p * (1 - p)).toFixed(3)}`;
+
+      tableBody.innerHTML = '';
+      const labels = [];
+      const data = [];
+      for (let i = 0; i <= n; i += 1) {
+        const prob = binomialProbability(n, p, i);
+        labels.push(i);
+        data.push(prob);
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${i}</td><td>${prob.toFixed(6)}</td>`;
+        if (i === x) tr.style.background = 'rgba(255,224,178,0.8)';
+        tableBody.appendChild(tr);
+      }
+      tableWrapper.style.display = 'block';
+      renderChart(labels, data, x);
+    }
+
+    function renderChart(labels, data, highlightX) {
+      const ctx = document.getElementById('binomial-chart');
+      if (binomialChart) binomialChart.destroy();
+      binomialChart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [{
+            label: 'P(X = x)',
+            data,
+            backgroundColor: labels.map(x => x === highlightX ? 'rgba(255,138,101,0.7)' : 'rgba(255,183,77,0.6)'),
+            borderColor: '#f57c00',
+            borderWidth: 1.5,
+            borderRadius: 10
+          }]
+        },
+        options: {
+          plugins: { legend: { display: false } },
+          scales: {
+            x: { title: { display: true, text: 'จำนวนครั้งที่สำเร็จ (x)', color: '#bf360c' } },
+            y: {
+              beginAtZero: true,
+              title: { display: true, text: 'ความน่าจะเป็น', color: '#bf360c' }
+            }
+          }
+        }
+      });
+    }
+
+    nInput.addEventListener('input', () => { updateDisplays(); calculate(); });
+    pInput.addEventListener('input', () => { updateDisplays(); calculate(); });
+    calcBtn.addEventListener('click', calculate);
+
+    updateDisplays();
+    calculate();
+  </script>
 </body>
 </html>

--- a/prob & Stats/content/09-hypergeometric.html
+++ b/prob & Stats/content/09-hypergeometric.html
@@ -2,13 +2,283 @@
 <html lang="th">
 <head>
   <meta charset="utf-8" />
-  <title>บทที่ 9: การแจกแจงแบบไฮเปอร์จีโอเมตริก</title>
+  <title>บทที่ 9: การแจกแจงไฮเปอร์จีออเมตริก</title>
   <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      min-height: 100vh;
+      background: linear-gradient(150deg, rgba(232,248,239,0.92), rgba(200,230,201,0.92));
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+    }
+    main.container { max-width: 1120px; margin: 0 auto; padding: clamp(2rem,5vw,3.5rem); }
+    header.hero {
+      background: linear-gradient(135deg, #2e7d32, #66bb6a);
+      color: #fff;
+      padding: clamp(2.8rem,6vw,4rem);
+      border-radius: 32px;
+      position: relative;
+      overflow: hidden;
+      margin-bottom: 2.4rem;
+      box-shadow: 0 30px 50px rgba(46,125,50,0.26);
+    }
+    header.hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 80% 20%, rgba(255,255,255,0.35), transparent 60%),
+                  radial-gradient(circle at 18% 70%, rgba(255,255,255,0.22), transparent 70%);
+    }
+    header.hero h1 { font-size: clamp(2.4rem,3vw+1.5rem,3.6rem); margin-bottom: 0.7rem; }
+    header.hero p { font-size: 1.1rem; max-width: 740px; line-height: 1.7; }
+    section.card {
+      background: rgba(255,255,255,0.95);
+      border-radius: 26px;
+      padding: clamp(1.7rem,4vw,2.7rem);
+      margin-bottom: 2.2rem;
+      box-shadow: 0 22px 38px rgba(56,142,60,0.18);
+    }
+    h2 {
+      display:flex;
+      align-items:center;
+      gap:0.75rem;
+      color:#1b5e20;
+      font-size:1.95rem;
+    }
+    .badge { background: rgba(200,230,201,0.85); color:#1b5e20; border-radius:999px; padding:0.18rem 0.85rem; font-weight:600; }
+    .grid { display:grid; gap:1.4rem; }
+    @media (min-width:950px) { .grid.two { grid-template-columns: repeat(2,minmax(0,1fr)); } }
+    article.definition {
+      border-radius:20px;
+      background: linear-gradient(155deg, rgba(200,230,201,0.55), rgba(232,245,233,0.7));
+      border:1px solid rgba(56,142,60,0.2);
+      padding:1.4rem 1.6rem;
+      display:grid;
+      gap:0.7rem;
+    }
+    article.definition strong { color:#1b5e20; font-size:1.1rem; }
+    .highlight { border-left:6px solid #43a047; background: rgba(76,175,80,0.12); border-radius:18px; padding:1rem 1.2rem; }
+    .code-box { background:#0d2614; color:#c8e6c9; padding:1rem 1.2rem; border-radius:14px; font-family:"Fira Code","Consolas",monospace; font-size:0.95rem; overflow-x:auto; }
+    .note { color:#2e7d32; font-size:0.95rem; }
+    .calculator { display:grid; gap:1rem; margin-top:1.1rem; }
+    .calculator label { font-weight:600; color:#1b5e20; }
+    .calculator input {
+      border-radius:14px;
+      border:1px solid rgba(46,125,50,0.35);
+      padding:0.65rem 0.85rem;
+      font-size:1rem;
+      background:rgba(241,248,233,0.9);
+    }
+    .calculator button {
+      border:none;
+      border-radius:999px;
+      padding:0.75rem 1.8rem;
+      background:linear-gradient(135deg,#2e7d32,#66bb6a);
+      color:#f1f8e9;
+      font-weight:600;
+      cursor:pointer;
+      justify-self:flex-start;
+      transition:transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .calculator button:hover { transform:translateY(-1px); box-shadow:0 12px 26px rgba(46,125,50,0.3); }
+    .result-card {
+      border-radius:18px;
+      background:rgba(76,175,80,0.14);
+      color:#1b5e20;
+      padding:1rem 1.3rem;
+      font-weight:600;
+      display:none;
+      gap:0.35rem;
+    }
+    .table-wrapper { overflow-x:auto; border-radius:16px; border:1px solid rgba(46,125,50,0.22); margin-top:1.3rem; display:none; }
+    table.styled { width:100%; border-collapse:collapse; min-width:520px; }
+    table.styled th, table.styled td { padding:0.85rem 1.1rem; text-align:center; }
+    table.styled thead { background:rgba(200,230,201,0.65); color:#1b5e20; }
+    table.styled tbody tr:nth-child(even) { background:rgba(232,245,233,0.6); }
+    details.toggle { background:rgba(200,230,201,0.5); border-radius:18px; padding:1rem 1.1rem; border:1px solid rgba(165,214,167,0.6); }
+    details.toggle summary { cursor:pointer; font-weight:600; color:#1b5e20; }
+    canvas { max-width:100%; }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="page">
   <main class="container">
-    <h1>บทที่ 9: การแจกแจงแบบไฮเปอร์จีโอเมตริก</h1>
-    <p>ส่วนนี้เตรียมไว้สำหรับเนื้อหาฉบับเต็มของบทเรียน 9. เพิ่มตัวอย่างและกรณีศึกษาได้ตามต้องการ.</p>
+    <header class="hero">
+      <h1>บทเรียนที่ 9: การแจกแจงไฮเปอร์จีออเมตริก (Hypergeometric)</h1>
+      <p>เข้าใจสถานการณ์สุ่มโดยไม่ใส่คืน ซึ่งทำให้โอกาสเปลี่ยนไปทุกครั้งที่หยิบ เช่น การสุ่มไพ่ การควบคุมคุณภาพ หรือการเลือกคณะกรรมการจากกลุ่มคนจำนวนจำกัด</p>
+    </header>
+
+    <section class="card" id="concept">
+      <h2><span class="badge">Concept</span> เมื่อการสุ่มไม่อิสระอีกต่อไป</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>สูตร PMF</strong>
+          <div class="code-box">P(X = x) = \dfrac{\binom{M}{x} \binom{N - M}{n - x}}{\binom{N}{n}}</div>
+          <div class="highlight">
+            <ul>
+              <li>N: จำนวนทั้งหมด</li>
+              <li>M: จำนวนที่เป็น “สำเร็จ” ในประชากร</li>
+              <li>n: ขนาดตัวอย่างที่หยิบ</li>
+              <li>x: จำนวนสำเร็จที่สนใจ</li>
+            </ul>
+          </div>
+        </article>
+        <article class="definition">
+          <strong>ค่าคาดหวัง</strong>
+          <div class="code-box">E(X) = n \left( \frac{M}{N} \right)</div>
+          <p class="note">สัดส่วนของสำเร็จในประชากร คูณด้วยจำนวนที่หยิบ</p>
+          <div class="highlight">
+            <p>หาก N ใหญ่มากเมื่อเทียบกับ n ผลลัพธ์จะใกล้เคียงกับการแจกแจงทวินามที่มี p = M/N</p>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="card" id="playground">
+      <h2><span class="badge">Playground</span> เครื่องคิดเลขไฮเปอร์จีออเมตริก</h2>
+      <div class="calculator">
+        <label for="N">ขนาดประชากรทั้งหมด (N)</label>
+        <input type="number" id="N" value="50" min="1" />
+        <label for="M">จำนวนที่เป็นความสำเร็จในประชากร (M)</label>
+        <input type="number" id="M" value="20" min="0" />
+        <label for="n">ขนาดตัวอย่างที่หยิบ (n)</label>
+        <input type="number" id="n" value="10" min="1" />
+        <label for="x">จำนวนสำเร็จที่สนใจ (x)</label>
+        <input type="number" id="x" value="4" min="0" />
+        <button id="calc-btn">คำนวณ</button>
+      </div>
+      <div id="result-card" class="result-card"></div>
+      <div class="table-wrapper" id="table-wrapper">
+        <table class="styled" id="table">
+          <thead><tr><th>x</th><th>P(X=x)</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <canvas id="chart" height="260" style="margin-top:1.5rem;"></canvas>
+    </section>
+
+    <section class="card" id="example">
+      <h2><span class="badge">Example</span> ควบคุมคุณภาพปากกา</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>โจทย์</strong>
+          <p>ปากกาทั้งหมด 12 ด้าม มีสีน้ำเงิน (สำเร็จ) 5 ด้าม ถ้าสุ่มหยิบ 3 ด้ามโดยไม่ใส่คืน อยากรู้ว่าหยิบได้สีน้ำเงิน 2 ด้ามพอดี</p>
+          <div class="code-box">N = 12, M = 5, n = 3, x = 2\nP(X=2) = \dfrac{\binom{5}{2} \binom{7}{1}}{\binom{12}{3}} = \dfrac{70}{220} \approx 0.318\nE(X) = 3 × (5/12) = 1.25</div>
+        </article>
+        <article class="definition">
+          <strong>ตีความ</strong>
+          <ul>
+            <li>โอกาสได้สีน้ำเงิน 2 ด้าม ≈ 31.8%</li>
+            <li>ค่าเฉลี่ย 1.25 ด้าม สะท้อนว่าการหยิบ 3 ด้ามโดยเฉลี่ยจะได้สีน้ำเงินประมาณ 1 ด้าม</li>
+            <li>หากหยิบเสร็จแล้วนำกลับ (ใส่คืน) จะกลับไปใช้การแจกแจงทวินามแทน</li>
+          </ul>
+          <div class="highlight">
+            <p>ไฮเปอร์จีออเมตริกเน้น <strong>ไม่ใส่คืน</strong> ทุกครั้งที่หยิบจะลดจำนวนของทั้งสองประเภท ทำให้ความน่าจะเป็นเปลี่ยนตลอดเวลา</p>
+          </div>
+        </article>
+      </div>
+      <details class="toggle" style="margin-top:1.2rem;">
+        <summary>เปรียบเทียบทวินาม vs ไฮเปอร์</summary>
+        <ul>
+          <li>ทวินาม: เหมาะกับการสุ่มที่ <em>เป็นอิสระ</em> หรือประชากรใหญ่มาก</li>
+          <li>ไฮเปอร์: เหมาะกับการสุ่ม <em>ไม่ใส่คืน</em> จากประชากรจำกัด</li>
+          <li>เมื่อ N ≥ 20n สามารถใช้ทวินามประมาณได้เพื่อลดขั้นตอน</li>
+        </ul>
+      </details>
+    </section>
   </main>
+
+  <script>
+    const NInput = document.getElementById('N');
+    const MInput = document.getElementById('M');
+    const nInput = document.getElementById('n');
+    const xInput = document.getElementById('x');
+    const calcBtn = document.getElementById('calc-btn');
+    const resultCard = document.getElementById('result-card');
+    const tableWrapper = document.getElementById('table-wrapper');
+    const tableBody = document.querySelector('#table tbody');
+    let chart;
+
+    function combination(n, k) {
+      if (k < 0 || k > n) return 0;
+      if (k === 0 || k === n) return 1;
+      k = Math.min(k, n - k);
+      let numerator = 1;
+      let denominator = 1;
+      for (let i = 1; i <= k; i += 1) {
+        numerator *= (n - (k - i));
+        denominator *= i;
+      }
+      return numerator / denominator;
+    }
+
+    function hyperProb(N, M, n, x) {
+      return (combination(M, x) * combination(N - M, n - x)) / combination(N, n);
+    }
+
+    function calculate() {
+      const N = Math.max(1, parseInt(NInput.value, 10) || 1);
+      const M = Math.min(Math.max(0, parseInt(MInput.value, 10) || 0), N);
+      const n = Math.min(Math.max(1, parseInt(nInput.value, 10) || 1), N);
+      const xMax = Math.min(M, n);
+      const x = Math.min(Math.max(parseInt(xInput.value, 10) || 0, 0), xMax);
+      MInput.value = M;
+      nInput.value = n;
+      xInput.value = x;
+
+      const probability = hyperProb(N, M, n, x);
+      resultCard.style.display = 'grid';
+      resultCard.innerHTML = `P(X = ${x}) = ${probability.toFixed(6)} | E(X) = ${(n * (M / N)).toFixed(3)}`;
+
+      tableBody.innerHTML = '';
+      const labels = [];
+      const data = [];
+      for (let i = 0; i <= xMax; i += 1) {
+        const prob = hyperProb(N, M, n, i);
+        labels.push(i);
+        data.push(prob);
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${i}</td><td>${prob.toFixed(6)}</td>`;
+        if (i === x) tr.style.background = 'rgba(200,230,201,0.85)';
+        tableBody.appendChild(tr);
+      }
+      tableWrapper.style.display = 'block';
+      renderChart(labels, data, x);
+    }
+
+    function renderChart(labels, data, highlightX) {
+      const ctx = document.getElementById('chart');
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [{
+            label: 'P(X = x)',
+            data,
+            backgroundColor: labels.map(v => v === highlightX ? 'rgba(102,187,106,0.7)' : 'rgba(165,214,167,0.6)'),
+            borderColor: '#2e7d32',
+            borderWidth: 1.5,
+            borderRadius: 10
+          }]
+        },
+        options: {
+          plugins: { legend: { display: false } },
+          scales: {
+            x: { title: { display: true, text: 'จำนวนสำเร็จ (x)', color: '#1b5e20' } },
+            y: {
+              beginAtZero: true,
+              title: { display: true, text: 'ความน่าจะเป็น', color: '#1b5e20' }
+            }
+          }
+        }
+      });
+    }
+
+    calcBtn.addEventListener('click', calculate);
+    [NInput, MInput, nInput, xInput].forEach(el => el.addEventListener('change', calculate));
+
+    calculate();
+  </script>
 </body>
 </html>

--- a/prob & Stats/content/10-poisson.html
+++ b/prob & Stats/content/10-poisson.html
@@ -2,13 +2,321 @@
 <html lang="th">
 <head>
   <meta charset="utf-8" />
-  <title>บทที่ 10: การแจกแจงปัวซอง</title>
+  <title>บทที่ 10: การแจกแจงปัวซง</title>
   <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      min-height: 100vh;
+      background: linear-gradient(150deg, rgba(236,239,241,0.92), rgba(207,216,220,0.92));
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+    }
+    main.container { max-width: 1120px; margin: 0 auto; padding: clamp(2rem,5vw,3.5rem); }
+    header.hero {
+      background: linear-gradient(135deg, #37474f, #607d8b);
+      color: #fff;
+      padding: clamp(2.8rem,6vw,4rem);
+      border-radius: 32px;
+      position: relative;
+      overflow: hidden;
+      margin-bottom: 2.4rem;
+      box-shadow: 0 30px 50px rgba(55,71,79,0.28);
+    }
+    header.hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 80% 20%, rgba(255,255,255,0.32), transparent 60%),
+                  radial-gradient(circle at 18% 70%, rgba(255,255,255,0.18), transparent 70%);
+    }
+    header.hero h1 { font-size: clamp(2.4rem,3vw+1.5rem,3.6rem); margin-bottom: 0.75rem; }
+    header.hero p { font-size: 1.12rem; max-width: 760px; line-height: 1.7; }
+    section.card {
+      background: rgba(255,255,255,0.95);
+      border-radius: 26px;
+      padding: clamp(1.7rem,4vw,2.7rem);
+      margin-bottom: 2.2rem;
+      box-shadow: 0 22px 38px rgba(55,71,79,0.18);
+    }
+    h2 {
+      display:flex;
+      align-items:center;
+      gap:0.75rem;
+      color:#37474f;
+      font-size:1.95rem;
+    }
+    .badge { background: rgba(176,190,197,0.8); color:#263238; border-radius:999px; padding:0.18rem 0.9rem; font-weight:600; }
+    .grid { display:grid; gap:1.4rem; }
+    @media (min-width:950px) { .grid.two { grid-template-columns: repeat(2,minmax(0,1fr)); } }
+    article.definition {
+      border-radius:20px;
+      background: linear-gradient(155deg, rgba(207,216,220,0.6), rgba(236,239,241,0.75));
+      border:1px solid rgba(96,125,139,0.22);
+      padding:1.4rem 1.6rem;
+      display:grid;
+      gap:0.7rem;
+    }
+    article.definition strong { font-size:1.1rem; color:#263238; }
+    .highlight { border-left:6px solid #607d8b; background:rgba(96,125,139,0.12); border-radius:18px; padding:1rem 1.2rem; }
+    .code-box { background:#1c262b; color:#cfd8dc; padding:1rem 1.2rem; border-radius:14px; font-family:"Fira Code","Consolas",monospace; font-size:0.95rem; overflow-x:auto; }
+    .note { color:#37474f; font-size:0.95rem; }
+    .calculator { display:grid; gap:1rem; margin-top:1.1rem; }
+    .calculator label { font-weight:600; color:#263238; }
+    .calculator input, .calculator select {
+      border-radius:14px;
+      border:1px solid rgba(96,125,139,0.35);
+      padding:0.65rem 0.85rem;
+      font-size:1rem;
+      background:rgba(248,249,250,0.9);
+    }
+    .calculator input[type="range"] { padding:0; }
+    .calculator button {
+      border:none;
+      border-radius:999px;
+      padding:0.75rem 1.8rem;
+      background:linear-gradient(135deg,#455a64,#78909c);
+      color:#eceff1;
+      font-weight:600;
+      cursor:pointer;
+      justify-self:flex-start;
+      transition:transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .calculator button:hover { transform:translateY(-1px); box-shadow:0 12px 26px rgba(69,90,100,0.3); }
+    .result-card {
+      border-radius:18px;
+      background:rgba(96,125,139,0.15);
+      color:#263238;
+      padding:1rem 1.3rem;
+      font-weight:600;
+      display:none;
+      gap:0.35rem;
+    }
+    .table-wrapper { overflow-x:auto; border-radius:16px; border:1px solid rgba(96,125,139,0.22); margin-top:1.3rem; display:none; }
+    table.styled { width:100%; border-collapse:collapse; min-width:520px; }
+    table.styled th, table.styled td { padding:0.85rem 1.1rem; text-align:center; }
+    table.styled thead { background:rgba(176,190,197,0.65); color:#263238; }
+    table.styled tbody tr:nth-child(even) { background:rgba(224,230,233,0.65); }
+    details.toggle { background:rgba(207,216,220,0.55); border-radius:18px; padding:1rem 1.1rem; border:1px solid rgba(176,190,197,0.6); }
+    details.toggle summary { cursor:pointer; font-weight:600; color:#263238; }
+    canvas { max-width:100%; }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="page">
   <main class="container">
-    <h1>บทที่ 10: การแจกแจงปัวซอง</h1>
-    <p>ส่วนนี้เตรียมไว้สำหรับเนื้อหาฉบับเต็มของบทเรียน 10. เพิ่มตัวอย่างและกรณีศึกษาได้ตามต้องการ.</p>
+    <header class="hero">
+      <h1>บทเรียนที่ 10: การแจกแจงปัวซง (Poisson)</h1>
+      <p>แบบจำลองสำหรับการนับจำนวนเหตุการณ์ที่เกิดขึ้นแบบสุ่มภายในขอบเขตที่กำหนด เมื่อเรารู้เพียงอัตราเฉลี่ยต่อช่วงเวลา พื้นที่ หรือปริมาตร</p>
+    </header>
+
+    <section class="card" id="concept">
+      <h2><span class="badge">Concept</span> นับเหตุการณ์ในขอบเขต</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>สูตร PMF</strong>
+          <div class="code-box">P(X = x) = \dfrac{e^{-\lambda} \lambda^x}{x!}</div>
+          <div class="highlight">
+            <ul>
+              <li>X: จำนวนเหตุการณ์ที่เกิดขึ้น</li>
+              <li>λ (แลมบ์ดา): ค่าเฉลี่ยของเหตุการณ์ต่อช่วง</li>
+              <li>ใช้กับเหตุการณ์ที่เกิดอย่างเป็นอิสระและอัตราคงที่</li>
+            </ul>
+          </div>
+        </article>
+        <article class="definition">
+          <strong>ค่าเฉลี่ย = ความแปรปรวน</strong>
+          <div class="code-box">E(X) = \lambda, \quad V(X) = \lambda</div>
+          <p class="note">จุดเด่นของปัวซงคือค่าเฉลี่ยเท่ากับความแปรปรวนเสมอ</p>
+          <div class="highlight">
+            <p>หากต้องการเปลี่ยนขอบเขตเวลา/พื้นที่ ต้องปรับ λ ให้สอดคล้อง เช่น λ = 8 สายต่อชั่วโมง ⇒ λ = 4 สายต่อ 30 นาที</p>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="card" id="playground">
+      <h2><span class="badge">Playground</span> เครื่องคิดเลขการแจกแจงปัวซง</h2>
+      <div class="calculator">
+        <label for="scenario">เลือกสถานการณ์</label>
+        <select id="scenario">
+          <option value="">-- เลือก --</option>
+          <option value="call">ศูนย์บริการรับสายเฉลี่ย 4 สาย/ชม.</option>
+          <option value="email">อีเมลเข้ามาเฉลี่ย 12 ฉบับ/วัน</option>
+          <option value="defect">จุดบกพร่องเฉลี่ย 2 จุด/ตารางเมตร</option>
+        </select>
+        <label for="lambda-input">ค่าเฉลี่ยต่อช่วง (λ): <strong id="lambda-display">4.00</strong></label>
+        <input type="range" id="lambda-input" min="0.1" max="20" step="0.1" value="4" />
+        <label for="x-input">จำนวนเหตุการณ์ที่สนใจ (x)</label>
+        <input type="number" id="x-input" value="2" min="0" />
+        <button id="calc-btn">คำนวณความน่าจะเป็น</button>
+        <button id="cum-btn">คำนวณ P(X &le; x)</button>
+      </div>
+      <div id="result-card" class="result-card"></div>
+      <div id="cum-card" class="result-card" style="margin-top:0.8rem;"></div>
+      <div class="table-wrapper" id="table-wrapper">
+        <table class="styled" id="poisson-table">
+          <thead><tr><th>x</th><th>P(X=x)</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <canvas id="poisson-chart" height="260" style="margin-top:1.4rem;"></canvas>
+    </section>
+
+    <section class="card" id="example">
+      <h2><span class="badge">Example</span> โทรศัพท์เข้า 2 สายใน 1 ชั่วโมง</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>โจทย์</strong>
+          <p>ศูนย์บริการได้รับโทรศัพท์เฉลี่ย 4 สายต่อชั่วโมง อยากรู้ความน่าจะเป็นที่จะมีสายเข้า 2 สายในชั่วโมงหน้า</p>
+          <div class="code-box">λ = 4, x = 2\nP(X=2) = e^{-4} 4^2 / 2! \approx 0.1464\nP(X < 2) = P(0) + P(1) \approx 0.0915</div>
+        </article>
+        <article class="definition">
+          <strong>การตีความ</strong>
+          <ul>
+            <li>โอกาส 14.64% ที่จะมีสายเข้า 2 สายพอดี</li>
+            <li>โอกาส 9.15% ที่จะมีสายเข้าน้อยกว่า 2 สาย</li>
+            <li>ค่าเฉลี่ยและความแปรปรวนเท่ากับ 4 สอดคล้องกับลักษณะปัวซง</li>
+          </ul>
+          <div class="highlight">
+            <p>ปัวซงเหมาะกับเหตุการณ์ "นับจำนวน" เช่น ยอดคนเข้าเว็บไซต์ต่อนาที จุดบกพร่องบนผ้า หรือจำนวนรถที่ผ่านสี่แยก</p>
+          </div>
+        </article>
+      </div>
+      <details class="toggle" style="margin-top:1.2rem;">
+        <summary>Tips</summary>
+        <ul>
+          <li>หากต้องการ P(X ≥ k) ให้ใช้ 1 − P(X &lt; k)</li>
+          <li>เมื่อ λ ใหญ่ (มากกว่า ~10) รูปร่างจะใกล้ปกติ สามารถใช้ Normal Approximation ได้</li>
+          <li>หากเหตุการณ์มีโอกาสเกิดสูงในแต่ละครั้ง ควรใช้การแจกแจงอื่นแทน (เช่น Binomial)</li>
+        </ul>
+      </details>
+    </section>
   </main>
+
+  <script>
+    const scenarioSelect = document.getElementById('scenario');
+    const lambdaInput = document.getElementById('lambda-input');
+    const lambdaDisplay = document.getElementById('lambda-display');
+    const xInput = document.getElementById('x-input');
+    const calcBtn = document.getElementById('calc-btn');
+    const cumBtn = document.getElementById('cum-btn');
+    const resultCard = document.getElementById('result-card');
+    const cumCard = document.getElementById('cum-card');
+    const tableWrapper = document.getElementById('table-wrapper');
+    const tableBody = document.querySelector('#poisson-table tbody');
+    let poissonChart;
+
+    const scenarios = {
+      call: { lambda: 4, x: 2 },
+      email: { lambda: 12, x: 10 },
+      defect: { lambda: 2, x: 0 }
+    };
+
+    scenarioSelect.addEventListener('change', () => {
+      const sc = scenarios[scenarioSelect.value];
+      if (!sc) return;
+      lambdaInput.value = sc.lambda;
+      xInput.value = sc.x;
+      updateLambda();
+      calculate();
+      calculateCumulative();
+    });
+
+    function factorial(n) {
+      if (n === 0 || n === 1) return 1;
+      let result = 1;
+      for (let i = 2; i <= n; i += 1) result *= i;
+      return result;
+    }
+
+    function poisson(lambda, x) {
+      return Math.exp(-lambda) * Math.pow(lambda, x) / factorial(x);
+    }
+
+    function updateLambda() {
+      const lambda = parseFloat(lambdaInput.value);
+      lambdaDisplay.textContent = lambda.toFixed(2);
+      xInput.min = 0;
+      xInput.step = 1;
+      xInput.value = Math.max(0, Math.round(parseFloat(xInput.value) || 0));
+    }
+
+    function calculate() {
+      const lambda = parseFloat(lambdaInput.value);
+      const x = Math.max(0, Math.round(parseFloat(xInput.value) || 0));
+      xInput.value = x;
+      const probability = poisson(lambda, x);
+      resultCard.style.display = 'grid';
+      resultCard.innerHTML = `P(X = ${x}) = ${probability.toFixed(6)} | E(X) = ${lambda.toFixed(3)} | V(X) = ${lambda.toFixed(3)}`;
+      buildTable(lambda, x);
+    }
+
+    function calculateCumulative() {
+      const lambda = parseFloat(lambdaInput.value);
+      const x = Math.max(0, Math.round(parseFloat(xInput.value) || 0));
+      let sum = 0;
+      for (let i = 0; i <= x; i += 1) {
+        sum += poisson(lambda, i);
+      }
+      cumCard.style.display = 'grid';
+      cumCard.innerHTML = `P(X \u2264 ${x}) = ${sum.toFixed(6)} | P(X > ${x}) = ${(1 - sum).toFixed(6)}`;
+    }
+
+    function buildTable(lambda, highlightX) {
+      tableBody.innerHTML = '';
+      const labels = [];
+      const data = [];
+      const maxX = Math.min(30, Math.max(highlightX + 5, Math.ceil(lambda + 4 * Math.sqrt(lambda))));
+      for (let i = 0; i <= maxX; i += 1) {
+        const prob = poisson(lambda, i);
+        labels.push(i);
+        data.push(prob);
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${i}</td><td>${prob.toFixed(6)}</td>`;
+        if (i === highlightX) tr.style.background = 'rgba(176,190,197,0.8)';
+        tableBody.appendChild(tr);
+      }
+      tableWrapper.style.display = 'block';
+      renderChart(labels, data, highlightX);
+    }
+
+    function renderChart(labels, data, highlightX) {
+      const ctx = document.getElementById('poisson-chart');
+      if (poissonChart) poissonChart.destroy();
+      poissonChart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [{
+            label: 'P(X = x)',
+            data,
+            backgroundColor: labels.map(x => x === highlightX ? 'rgba(120,144,156,0.7)' : 'rgba(176,190,197,0.6)'),
+            borderColor: '#455a64',
+            borderWidth: 1.5,
+            borderRadius: 10
+          }]
+        },
+        options: {
+          plugins: { legend: { display: false } },
+          scales: {
+            x: { title: { display: true, text: 'จำนวนเหตุการณ์ (x)', color: '#37474f' } },
+            y: {
+              beginAtZero: true,
+              title: { display: true, text: 'ความน่าจะเป็น', color: '#37474f' }
+            }
+          }
+        }
+      });
+    }
+
+    lambdaInput.addEventListener('input', () => { updateLambda(); calculate(); calculateCumulative(); });
+    xInput.addEventListener('change', () => { calculate(); calculateCumulative(); });
+    calcBtn.addEventListener('click', () => { calculate(); });
+    cumBtn.addEventListener('click', calculateCumulative);
+
+    updateLambda();
+    calculate();
+    calculateCumulative();
+  </script>
 </body>
 </html>

--- a/prob & Stats/content/17-ci-one-mean.html
+++ b/prob & Stats/content/17-ci-one-mean.html
@@ -1,0 +1,395 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8" />
+  <title>บทที่ 17: ช่วงความเชื่อมั่นสำหรับค่าเฉลี่ยเดียว</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      --accent: #00695c;
+      --accent-light: #4db6ac;
+      --accent-dark: #004d40;
+      --card-bg: rgba(236, 253, 245, 0.92);
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+      background: radial-gradient(circle at 12% 18%, rgba(77, 182, 172, 0.28), transparent 65%),
+                  radial-gradient(circle at 82% 12%, rgba(0, 105, 92, 0.18), transparent 60%),
+                  linear-gradient(180deg, rgba(232, 245, 233, 0.9), rgba(224, 242, 241, 0.94));
+      min-height: 100vh;
+    }
+    main.container {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: clamp(2rem, 5vw, 3.5rem);
+      display: grid;
+      gap: 2.2rem;
+    }
+    header.hero {
+      background: linear-gradient(135deg, var(--accent), var(--accent-light));
+      color: #fff;
+      padding: clamp(2.6rem, 6vw, 4rem);
+      border-radius: 32px;
+      position: relative;
+      overflow: hidden;
+      box-shadow: 0 32px 54px rgba(0, 105, 92, 0.26);
+    }
+    header.hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 78% 20%, rgba(255,255,255,0.45), transparent 55%),
+                  radial-gradient(circle at 15% 75%, rgba(255,255,255,0.28), transparent 70%);
+    }
+    header.hero h1 {
+      font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem);
+      margin-bottom: 0.75rem;
+    }
+    header.hero p { font-size: 1.12rem; max-width: 720px; line-height: 1.7; }
+    section.card {
+      background: var(--card-bg);
+      border-radius: 26px;
+      padding: clamp(1.8rem, 4vw, 2.6rem);
+      box-shadow: 0 20px 36px rgba(0, 96, 86, 0.12);
+      backdrop-filter: blur(6px);
+      display: grid;
+      gap: 1.1rem;
+    }
+    section.card h2 {
+      color: var(--accent);
+      font-size: 1.9rem;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin: 0;
+    }
+    .badge {
+      background: rgba(0, 77, 64, 0.12);
+      color: var(--accent);
+      padding: 0.18rem 0.85rem;
+      border-radius: 999px;
+      font-size: 0.9rem;
+      font-weight: 600;
+    }
+    .grid { display: grid; gap: 1.2rem; }
+    @media (min-width: 960px) { .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    article.definition {
+      padding: 1.35rem 1.6rem;
+      border-radius: 20px;
+      background: rgba(224, 242, 241, 0.85);
+      border: 1px solid rgba(0, 121, 107, 0.2);
+      display: grid;
+      gap: 0.6rem;
+    }
+    article.definition strong { color: var(--accent-dark); font-size: 1.05rem; }
+    .highlight {
+      border-left: 6px solid var(--accent);
+      padding: 1rem 1.25rem;
+      background: rgba(0, 105, 92, 0.1);
+      border-radius: 18px;
+      line-height: 1.7;
+    }
+    .note { color: var(--accent-dark); font-size: 0.95rem; }
+    .calculator { display: grid; gap: 1rem; margin-top: 0.8rem; }
+    .calculator label { font-weight: 600; color: var(--accent-dark); }
+    .calculator input, .calculator select {
+      padding: 0.75rem 1rem;
+      border-radius: 14px;
+      border: 1px solid rgba(0, 105, 92, 0.28);
+      font-size: 1rem;
+      background: rgba(255,255,255,0.92);
+    }
+    .calculator button {
+      background: linear-gradient(135deg, var(--accent-dark), var(--accent));
+      color: #fff;
+      border: 0;
+      border-radius: 14px;
+      padding: 0.85rem 1.2rem;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .calculator button:hover { transform: translateY(-2px); box-shadow: 0 16px 30px rgba(0, 105, 92, 0.22); }
+    .result-card {
+      background: rgba(255,255,255,0.95);
+      border-radius: 20px;
+      padding: 1.2rem 1.4rem;
+      border: 1px solid rgba(0, 105, 92, 0.2);
+      display: grid;
+      gap: 0.6rem;
+    }
+    canvas { background: rgba(255,255,255,0.85); border-radius: 18px; padding: 1rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.6rem 0.75rem; text-align: left; }
+    th { background: rgba(0, 77, 64, 0.12); color: var(--accent-dark); }
+    tr:nth-child(even) { background: rgba(224, 242, 241, 0.6); }
+  </style>
+</head>
+<body class="page">
+  <main class="container">
+    <header class="hero">
+      <span class="badge">ช่วงความเชื่อมั่น (Confidence Interval)</span>
+      <h1>บทที่ 17: ช่วงความเชื่อมั่นสำหรับค่าเฉลี่ยประชากรเดียว (μ)</h1>
+      <p>เจาะลึกวิธีประมาณค่าเฉลี่ยของประชากรจากข้อมูลตัวอย่าง พร้อมทำความเข้าใจการเลือกสถิติอ้างอิง (z หรือ t) การตีความ และการสื่อสารผลลัพธ์ให้เข้าใจง่ายผ่านเครื่องมือเชิงโต้ตอบ.</p>
+    </header>
+
+    <section class="card">
+      <h2>1. ภาพรวมและเงื่อนไขการใช้งาน</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>เหตุผลที่ใช้ช่วงความเชื่อมั่น</strong>
+          <p>เราไม่มีทางรู้ค่าเฉลี่ยจริงของประชากร (μ) ได้โดยตรง จึงใช้ตัวอย่างมาประมาณและสร้าง <em>ช่วง</em> ที่น่าจะครอบคลุมค่าแท้จริงด้วยระดับความเชื่อมั่นที่กำหนด เช่น 95%.</p>
+          <ul>
+            <li>ใช้เมื่อมีข้อมูลเชิงปริมาณ (scale/interval)</li>
+            <li>สุ่มตัวอย่างอย่างเป็นอิสระ</li>
+            <li>ขนาดตัวอย่างค่อนข้างใหญ่ หรือข้อมูลใกล้เคียงปกติ</li>
+          </ul>
+        </article>
+        <article class="definition">
+          <strong>เลือกใช้สถิติอ้างอิงแบบใด?</strong>
+          <p>ตัวเลือกหลักขึ้นกับการรู้หรือไม่รู้ส่วนเบี่ยงเบนมาตรฐานของประชากร (σ) และขนาดตัวอย่าง:</p>
+          <ul>
+            <li><strong>ทราบ σ</strong> → ใช้การแจกแจงปกติมาตรฐาน (z)</li>
+            <li><strong>ไม่ทราบ σ</strong> → ใช้ส่วนเบี่ยงเบนมาตรฐานตัวอย่าง (s) และอ้างอิง t ที่ df = n − 1</li>
+            <li>เมื่อ n ≥ 30 การแจกแจง t ใกล้เคียง z มาก</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>2. สูตรและขั้นตอนคำนวณ</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>สูตรทั่วไป</strong>
+          <p>ช่วงความเชื่อมั่นสำหรับค่าเฉลี่ยมีรูปแบบ <code>สถิติประมาณ ± ค่าขอบเขตผิดพลาด</code></p>
+          <ul>
+            <li><span class="badge">ทราบ σ</span> \(\bar{x} \pm z_{\alpha/2} \dfrac{\sigma}{\sqrt{n}}\)</li>
+            <li><span class="badge">ไม่ทราบ σ</span> \(\bar{x} \pm t_{\alpha/2,\, n-1} \dfrac{s}{\sqrt{n}}\)</li>
+            <li>\(\alpha = 1 - \text{ระดับความเชื่อมั่น}\)</li>
+          </ul>
+        </article>
+        <article class="definition">
+          <strong>ขั้นตอนแนะนำ</strong>
+          <ol>
+            <li>ตรวจสอบสมมติฐาน: สุ่มเป็นอิสระ, รูปแบบประชากร, ขนาดตัวอย่าง</li>
+            <li>เลือกสูตร: รู้/ไม่รู้ σ</li>
+            <li>คำนวณค่าเฉลี่ยตัวอย่าง, ส่วนเบี่ยงเบนมาตรฐาน, ขนาดตัวอย่าง</li>
+            <li>หา critical value ตามระดับความเชื่อมั่น</li>
+            <li>คำนวณช่วงและตีความ</li>
+          </ol>
+        </article>
+      </div>
+      <div class="highlight">
+        <strong>การตีความ</strong> ระดับความเชื่อมั่น 95% หมายถึง หากทำการสุ่มตัวอย่างซ้ำอย่างไม่สิ้นสุด 95% ของช่วงที่สร้างจะครอบคลุม μ จริง ไม่ใช่ “โอกาส 95% สำหรับช่วงเดียว”.
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>3. เครื่องมือสร้างช่วงความเชื่อมั่น</h2>
+      <p>กรอกข้อมูลจากตัวอย่างของคุณ ระบบจะคำนวณช่วงความเชื่อมั่นและแสดงรูปทรงการแจกแจงพร้อมไฮไลต์ช่วงที่ได้ทันที.</p>
+      <div class="calculator">
+        <label>เลือกกรณี
+          <select id="ci-type">
+            <option value="known">ทราบ σ ของประชากร (ใช้ z)</option>
+            <option value="unknown">ไม่ทราบ σ (ใช้ t)</option>
+          </select>
+        </label>
+        <label>ค่าเฉลี่ยตัวอย่าง (\(\bar{x}\))
+          <input type="number" id="sample-mean" value="82.5" step="0.01" />
+        </label>
+        <label>ส่วนเบี่ยงเบนมาตรฐาน <span id="spread-label">ประชากร (σ)</span>
+          <input type="number" id="spread" value="12" step="0.01" min="0" />
+        </label>
+        <label>ขนาดตัวอย่าง (n)
+          <input type="number" id="sample-size" value="35" min="2" />
+        </label>
+        <label>ระดับความเชื่อมั่น (%)
+          <input type="range" id="confidence" min="80" max="99" value="95" />
+        </label>
+        <div class="note">ระดับความเชื่อมั่น: <span id="conf-display">95%</span></div>
+        <button id="calc-btn">คำนวณช่วงความเชื่อมั่น</button>
+      </div>
+      <div class="result-card" id="result-card" style="display:none"></div>
+      <canvas id="ci-chart" height="220"></canvas>
+    </section>
+
+    <section class="card">
+      <h2>4. ตัวอย่างการตีความ</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>สถานการณ์</th>
+            <th>ข้อมูลตัวอย่าง</th>
+            <th>ช่วงความเชื่อมั่น 95%</th>
+            <th>การสื่อสารผลลัพธ์</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>เวลาเฉลี่ยตอบอีเมลลูกค้า</td>
+            <td>\(\bar{x}=12.4\) นาที, σ=3.1, n=40</td>
+            <td>[11.4, 13.4]</td>
+            <td>เรามั่นใจ 95% ว่าเวลาเฉลี่ยตอบอีเมลของทีมอยู่ระหว่าง 11.4 ถึง 13.4 นาที</td>
+          </tr>
+          <tr>
+            <td>คะแนนสอบวิชาสถิติ</td>
+            <td>\(\bar{x}=68.2\), s=8.7, n=24</td>
+            <td>[64.5, 71.9] (ใช้ t)</td>
+            <td>แม้ไม่รู้ σ แต่ตัวอย่างบ่งชี้ว่า μ อยู่ในช่วง 64.5–71.9 ด้วยความเชื่อมั่น 95%</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="note">ปรับความเชื่อมั่นให้สูงขึ้น → ช่วงกว้างขึ้น (เพิ่มความระมัดระวัง) แต่ทำให้การตัดสินใจยากขึ้นเล็กน้อย</p>
+    </section>
+
+    <section class="card">
+      <h2>5. Checklist ก่อนสรุปผล</h2>
+      <ul>
+        <li>✅ ตัวอย่างสุ่มเป็นอิสระจากกันหรือไม่?</li>
+        <li>✅ ข้อมูลไม่เบี่ยงเบนจากปกติอย่างรุนแรง (หรือ n ใหญ่พอ)?</li>
+        <li>✅ ระบุได้หรือยังว่าทราบหรือไม่ทราบ σ?</li>
+        <li>✅ ระบุระดับความเชื่อมั่นก่อนคำนวณ?</li>
+        <li>✅ การตีความพูดถึง <em>ค่าเฉลี่ยของประชากร</em> ไม่ใช่ค่าของแต่ละคน?</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.5/dist/jstat.min.js"></script>
+  <script>
+    const ciType = document.getElementById('ci-type');
+    const meanInput = document.getElementById('sample-mean');
+    const spreadInput = document.getElementById('spread');
+    const sizeInput = document.getElementById('sample-size');
+    const confInput = document.getElementById('confidence');
+    const confDisplay = document.getElementById('conf-display');
+    const calcBtn = document.getElementById('calc-btn');
+    const resultCard = document.getElementById('result-card');
+    const spreadLabel = document.getElementById('spread-label');
+    const ctx = document.getElementById('ci-chart');
+    let chart;
+
+    function updateLabel() {
+      spreadLabel.textContent = ciType.value === 'known' ? 'ประชากร (σ)' : 'ตัวอย่าง (s)';
+    }
+
+    function compute() {
+      const mean = parseFloat(meanInput.value);
+      const spread = Math.max(parseFloat(spreadInput.value), 0.00001);
+      const n = Math.max(parseInt(sizeInput.value, 10), 2);
+      sizeInput.value = n;
+      const confidence = parseInt(confInput.value, 10) / 100;
+      confDisplay.textContent = `${(confidence * 100).toFixed(0)}%`;
+
+      const alpha = 1 - confidence;
+      let critical = 0;
+      let se = spread / Math.sqrt(n);
+      let distType = 'z';
+      let df = n - 1;
+
+      if (ciType.value === 'known') {
+        critical = jStat.normal.inv(1 - alpha / 2, 0, 1);
+        distType = 'z';
+      } else {
+        critical = jStat.studentt.inv(1 - alpha / 2, df);
+        distType = 't';
+      }
+
+      const margin = critical * se;
+      const lower = mean - margin;
+      const upper = mean + margin;
+
+      resultCard.style.display = 'grid';
+      resultCard.innerHTML = `
+        <strong>สรุปผล</strong>
+        <span>ระดับความเชื่อมั่น: ${(confidence * 100).toFixed(1)}% | Critical value: ${critical.toFixed(3)} (${distType.toUpperCase()})</span>
+        <span>ค่าเฉลี่ยตัวอย่าง = ${mean.toFixed(3)}, SE = ${se.toFixed(3)}</span>
+        <span>ช่วงความเชื่อมั่น = [${lower.toFixed(3)}, ${upper.toFixed(3)}]</span>
+        <span class="note">ตีความ: เรามั่นใจ ${(confidence * 100).toFixed(1)}% ว่าค่าเฉลี่ยประชากรอยู่ในช่วงนี้</span>
+      `;
+
+      const points = 200;
+      const range = 4 * se;
+      const labels = [];
+      const base = [];
+      const highlight = [];
+      for (let i = 0; i <= points; i += 1) {
+        const x = mean - range + (2 * range * i) / points;
+        const standardized = (x - mean) / se;
+        const density = distType === 'z'
+          ? jStat.normal.pdf(standardized, 0, 1) / se
+          : jStat.studentt.pdf(standardized, df) / se;
+        labels.push(x.toFixed(3));
+        base.push(density);
+        highlight.push(x >= lower && x <= upper ? density : null);
+      }
+
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'การแจกแจงตัวอย่าง',
+              data: base,
+              borderColor: 'rgba(0,77,64,0.45)',
+              borderWidth: 2,
+              pointRadius: 0,
+              tension: 0.22,
+              fill: false
+            },
+            {
+              label: 'ช่วงความเชื่อมั่น',
+              data: highlight,
+              borderColor: 'rgba(0,150,136,0.9)',
+              backgroundColor: 'rgba(77,182,172,0.35)',
+              borderWidth: 2.5,
+              pointRadius: 0,
+              tension: 0.22,
+              fill: true
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          plugins: {
+            legend: { labels: { color: '#004d40' } },
+            tooltip: {
+              callbacks: {
+                title: items => `ค่าเฉลี่ย = ${items[0].label}`,
+                label: ctx => `ความหนาแน่น ~ ${Number(ctx.raw).toFixed(4)}`
+              }
+            }
+          },
+          scales: {
+            x: {
+              ticks: { color: '#004d40' },
+              title: { display: true, text: 'ค่าเฉลี่ยที่เป็นไปได้', color: '#004d40' }
+            },
+            y: {
+              ticks: { color: '#004d40' },
+              title: { display: true, text: 'ความหนาแน่น', color: '#004d40' }
+            }
+          }
+        }
+      });
+    }
+
+    confInput.addEventListener('input', () => { confDisplay.textContent = `${confInput.value}%`; });
+    ciType.addEventListener('change', () => {
+      updateLabel();
+      compute();
+    });
+    meanInput.addEventListener('input', compute);
+    spreadInput.addEventListener('input', compute);
+    sizeInput.addEventListener('input', compute);
+    confInput.addEventListener('change', compute);
+    calcBtn.addEventListener('click', compute);
+
+    updateLabel();
+    compute();
+  </script>
+</body>
+</html>

--- a/prob & Stats/content/18-ci-one-proportion.html
+++ b/prob & Stats/content/18-ci-one-proportion.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8" />
+  <title>บทที่ 18: ช่วงความเชื่อมั่นสำหรับสัดส่วนเดียว</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      --accent: #ad1457;
+      --accent-light: #f06292;
+      --accent-dark: #880e4f;
+      --card-bg: rgba(255, 240, 245, 0.94);
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+      background: radial-gradient(circle at 15% 20%, rgba(240, 98, 146, 0.28), transparent 60%),
+                  radial-gradient(circle at 85% 18%, rgba(173, 20, 87, 0.2), transparent 60%),
+                  linear-gradient(180deg, rgba(252, 228, 236, 0.92), rgba(248, 187, 208, 0.88));
+      min-height: 100vh;
+    }
+    main.container { max-width: 1100px; margin: 0 auto; padding: clamp(2rem, 5vw, 3.5rem); display: grid; gap: 2.2rem; }
+    header.hero {
+      background: linear-gradient(135deg, var(--accent), var(--accent-light));
+      color: #fff;
+      padding: clamp(2.6rem, 6vw, 4rem);
+      border-radius: 32px;
+      position: relative;
+      overflow: hidden;
+      box-shadow: 0 32px 54px rgba(173, 20, 87, 0.26);
+    }
+    header.hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 80% 20%, rgba(255,255,255,0.4), transparent 55%),
+                  radial-gradient(circle at 20% 75%, rgba(255,255,255,0.26), transparent 70%);
+    }
+    header.hero h1 { font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem); margin-bottom: 0.75rem; }
+    header.hero p { font-size: 1.12rem; max-width: 720px; line-height: 1.7; }
+    section.card {
+      background: var(--card-bg);
+      border-radius: 26px;
+      padding: clamp(1.8rem, 4vw, 2.6rem);
+      box-shadow: 0 20px 36px rgba(173, 20, 87, 0.12);
+      backdrop-filter: blur(6px);
+      display: grid;
+      gap: 1.1rem;
+    }
+    section.card h2 {
+      color: var(--accent);
+      font-size: 1.9rem;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin: 0;
+    }
+    .badge { background: rgba(136, 14, 79, 0.12); color: var(--accent-dark); padding: 0.2rem 0.8rem; border-radius: 999px; font-size: 0.88rem; font-weight: 600; }
+    .grid { display: grid; gap: 1.2rem; }
+    @media (min-width: 960px) { .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    article.definition { padding: 1.35rem 1.6rem; border-radius: 20px; background: rgba(255, 228, 236, 0.85); border: 1px solid rgba(173, 20, 87, 0.18); display: grid; gap: 0.6rem; }
+    article.definition strong { color: var(--accent-dark); font-size: 1.05rem; }
+    .highlight { border-left: 6px solid var(--accent); padding: 1rem 1.25rem; background: rgba(173, 20, 87, 0.1); border-radius: 18px; line-height: 1.7; }
+    .calculator { display: grid; gap: 1rem; margin-top: 0.8rem; }
+    .calculator label { font-weight: 600; color: var(--accent-dark); }
+    .calculator input, .calculator select {
+      padding: 0.75rem 1rem;
+      border-radius: 14px;
+      border: 1px solid rgba(173, 20, 87, 0.28);
+      font-size: 1rem;
+      background: rgba(255,255,255,0.95);
+    }
+    .calculator button {
+      background: linear-gradient(135deg, var(--accent-dark), var(--accent));
+      color: #fff;
+      border: 0;
+      border-radius: 14px;
+      padding: 0.85rem 1.2rem;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .calculator button:hover { transform: translateY(-2px); box-shadow: 0 16px 30px rgba(173, 20, 87, 0.2); }
+    .result-card { background: rgba(255,255,255,0.95); border-radius: 20px; padding: 1.2rem 1.4rem; border: 1px solid rgba(173, 20, 87, 0.18); display: grid; gap: 0.6rem; }
+    canvas { background: rgba(255,255,255,0.88); border-radius: 18px; padding: 1rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.6rem 0.75rem; text-align: left; }
+    th { background: rgba(240, 98, 146, 0.12); color: var(--accent-dark); }
+    tr:nth-child(even) { background: rgba(255, 228, 236, 0.6); }
+  </style>
+</head>
+<body class="page">
+  <main class="container">
+    <header class="hero">
+      <span class="badge">Confidence Interval for Proportion</span>
+      <h1>บทที่ 18: ช่วงความเชื่อมั่นสำหรับสัดส่วนประชากรเดียว (p)</h1>
+      <p>ใช้ตัวอย่างเพื่อประมาณสัดส่วนของประชากร เช่น อัตราการสนับสนุนสินค้า หรือเปอร์เซ็นต์ของผู้ป่วยที่หายขาด พร้อมเครื่องมือที่ช่วยคำนวณและตีความผลได้อย่างมั่นใจ.</p>
+    </header>
+
+    <section class="card">
+      <h2>1. แนวคิดหลักและเงื่อนไข</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>ค่าสัดส่วนประชากร (p)</strong>
+          <p>คือสัดส่วนที่แท้จริงของประชากรที่มีคุณสมบัติที่เราสนใจ (เช่น ผู้ใช้ที่ชอบฟีเจอร์ใหม่). เราประมาณค่าด้วยสัดส่วนตัวอย่าง \(\hat{p} = x/n\).</p>
+          <ul>
+            <li>ข้อมูลเป็นลักษณะสำเร็จ/ล้มเหลว (binary)</li>
+            <li>สุ่มตัวอย่างอย่างเป็นอิสระ</li>
+            <li>ขนาดตัวอย่างควรเพียงพอ: \(n\hat{p} \ge 10\) และ \(n(1-\hat{p}) \ge 10\)</li>
+          </ul>
+        </article>
+        <article class="definition">
+          <strong>สูตรพื้นฐาน</strong>
+          <p>ช่วงความเชื่อมั่นแบบ Wald ที่ใช้บ่อยมีรูปแบบ</p>
+          <p>\[ \hat{p} \pm z_{\alpha/2} \sqrt{ \dfrac{\hat{p}(1-\hat{p})}{n} } \]</p>
+          <p class="note">เมื่อขนาดตัวอย่างไม่มาก แนะนำใช้ Wilson หรือ Agresti-Coull เพื่อให้ช่วงสมดุลยิ่งขึ้น</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>2. เปรียบเทียบสูตรยอดนิยม</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>Wald (มาตรฐาน)</strong>
+          <ul>
+            <li>คำนวณง่าย</li>
+            <li>แม่นยำดีเมื่อ n ใหญ่</li>
+            <li>อาจให้ขอบเขตเกิน [0,1]</li>
+          </ul>
+        </article>
+        <article class="definition">
+          <strong>Wilson (Score Interval)</strong>
+          <ul>
+            <li>ปรับช่วงด้วย z ทั้งในตัวเศษและส่วน</li>
+            <li>ให้ช่วงสมมาตรมากขึ้นและอยู่ใน [0,1]</li>
+            <li>เป็นตัวเลือกเริ่มต้นที่ดีเมื่อ n กลางๆ</li>
+          </ul>
+        </article>
+      </div>
+      <div class="highlight">
+        <strong>ทิป</strong> Wilson interval คำนวณเป็น \(\frac{\hat{p}+\frac{z^2}{2n} \pm z \sqrt{\frac{\hat{p}(1-\hat{p})}{n}+\frac{z^2}{4n^2}}}{1+\frac{z^2}{n}}\)
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>3. เครื่องคำนวณช่วงความเชื่อมั่นสำหรับสัดส่วนเดียว</h2>
+      <p>ป้อนจำนวนความสำเร็จในตัวอย่างและเลือกสูตรที่ต้องการ ชาร์ตด้านล่างจะแสดงการแจกแจงประมาณแบบปกติพร้อมช่วงที่ได้.</p>
+      <div class="calculator">
+        <label>จำนวนความสำเร็จ (x)
+          <input type="number" id="success" value="145" min="0" />
+        </label>
+        <label>ขนาดตัวอย่าง (n)
+          <input type="number" id="total" value="400" min="1" />
+        </label>
+        <label>ระดับความเชื่อมั่น (%)
+          <input type="range" id="conf" min="80" max="99" value="95" />
+        </label>
+        <div class="note">ระดับความเชื่อมั่นปัจจุบัน: <span id="conf-text">95%</span></div>
+        <label>เลือกสูตร
+          <select id="method">
+            <option value="wald">Wald (มาตรฐาน)</option>
+            <option value="wilson">Wilson Score</option>
+          </select>
+        </label>
+        <button id="run">คำนวณช่วง</button>
+      </div>
+      <div class="result-card" id="summary" style="display:none"></div>
+      <canvas id="prop-chart" height="220"></canvas>
+    </section>
+
+    <section class="card">
+      <h2>4. ตัวอย่างเชิงสถานการณ์</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>กรณีศึกษา</th>
+            <th>ข้อมูลตัวอย่าง</th>
+            <th>ช่วง 95%</th>
+            <th>สรุปผล</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>อัตราลูกค้าที่กลับมาซื้อซ้ำ</td>
+            <td>x=62 จาก n=150</td>
+            <td>[0.344, 0.503] (Wilson)</td>
+            <td>มั่นใจ 95% ว่าระหว่าง 34.4%–50.3% ของลูกค้าทั้งหมดกลับมาซื้อซ้ำ</td>
+          </tr>
+          <tr>
+            <td>อัตราผู้ป่วยตอบสนองต่อการรักษา</td>
+            <td>x=178 จาก n=220</td>
+            <td>[0.755, 0.851]</td>
+            <td>บ่งชี้ว่ามากกว่า 75% ของผู้ป่วยน่าจะตอบสนองต่อการรักษานี้</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="note">เมื่อตัวอย่างน้อยหรือ \(\hat{p}\) ใกล้ 0/1 ให้พิจารณา Wilson หรือ Clopper-Pearson เพื่อความแม่นยำ</p>
+    </section>
+
+    <section class="card">
+      <h2>5. Checklist</h2>
+      <ul>
+        <li>✅ ข้อมูลเป็นการสุ่มและเป็นอิสระ</li>
+        <li>✅ ตรวจสอบเงื่อนไข \(n\hat{p}\) และ \(n(1-\hat{p})\)</li>
+        <li>✅ ระบุสูตรที่ใช้ในรายงาน</li>
+        <li>✅ ช่วงที่ได้ไม่ออกนอกขอบเขต [0,1]</li>
+        <li>✅ ตีความด้วยภาษาง่าย เช่น “ร้อยละของทั้งประชากร”</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.5/dist/jstat.min.js"></script>
+  <script>
+    const successInput = document.getElementById('success');
+    const totalInput = document.getElementById('total');
+    const confInput = document.getElementById('conf');
+    const confText = document.getElementById('conf-text');
+    const methodSelect = document.getElementById('method');
+    const runBtn = document.getElementById('run');
+    const summary = document.getElementById('summary');
+    const ctx = document.getElementById('prop-chart');
+    let chart;
+
+    function computeInterval(x, n, confidence, method) {
+      const phat = x / n;
+      const alpha = 1 - confidence;
+      const z = jStat.normal.inv(1 - alpha / 2, 0, 1);
+      let lower;
+      let upper;
+      if (method === 'wilson') {
+        const denom = 1 + (z * z) / n;
+        const center = (phat + (z * z) / (2 * n)) / denom;
+        const margin = (z * Math.sqrt((phat * (1 - phat)) / n + (z * z) / (4 * n * n))) / denom;
+        lower = center - margin;
+        upper = center + margin;
+      } else {
+        const se = Math.sqrt((phat * (1 - phat)) / n);
+        const margin = z * se;
+        lower = phat - margin;
+        upper = phat + margin;
+      }
+      return {
+        phat,
+        lower: Math.max(0, lower),
+        upper: Math.min(1, upper),
+        z
+      };
+    }
+
+    function updateChart(mean, se, lower, upper) {
+      const points = 200;
+      const range = Math.max(0.15, 6 * se);
+      const start = Math.max(0, mean - range / 2);
+      const end = Math.min(1, mean + range / 2);
+      const labels = [];
+      const base = [];
+      const highlight = [];
+      for (let i = 0; i <= points; i += 1) {
+        const x = start + ((end - start) * i) / points;
+        const std = (x - mean) / (se || 1e-6);
+        const density = jStat.normal.pdf(std, 0, 1) / (se || 1e-6);
+        labels.push(x.toFixed(3));
+        base.push(density);
+        highlight.push(x >= lower && x <= upper ? density : null);
+      }
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Approximate sampling distribution',
+              data: base,
+              borderColor: 'rgba(173,20,87,0.4)',
+              borderWidth: 2,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: false
+            },
+            {
+              label: 'ช่วงความเชื่อมั่น',
+              data: highlight,
+              borderColor: 'rgba(244,143,177,0.95)',
+              backgroundColor: 'rgba(244,143,177,0.35)',
+              borderWidth: 2.4,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: true
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { labels: { color: '#880e4f' } } },
+          scales: {
+            x: { title: { display: true, text: 'สัดส่วนที่เป็นไปได้', color: '#880e4f' }, ticks: { color: '#880e4f' } },
+            y: { title: { display: true, text: 'ความหนาแน่น (โดยประมาณ)', color: '#880e4f' }, ticks: { color: '#880e4f' } }
+          }
+        }
+      });
+    }
+
+    function calculate() {
+      const x = Math.max(parseInt(successInput.value, 10), 0);
+      const n = Math.max(parseInt(totalInput.value, 10), 1);
+      const confidence = parseInt(confInput.value, 10) / 100;
+      const method = methodSelect.value;
+      successInput.value = x;
+      totalInput.value = n;
+      const { phat, lower, upper, z } = computeInterval(x, n, confidence, method);
+      const se = Math.sqrt((phat * (1 - phat)) / n);
+      summary.style.display = 'grid';
+      summary.innerHTML = `
+        <strong>ผลลัพธ์</strong>
+        <span>\u005Chat{p} = ${(phat * 100).toFixed(2)}% จากข้อมูล (${x}/${n})</span>
+        <span>ระดับความเชื่อมั่น ${(confidence * 100).toFixed(1)}% | z_{\alpha/2} = ${z.toFixed(3)}</span>
+        <span>ช่วงความเชื่อมั่น (${method === 'wilson' ? 'Wilson' : 'Wald'}) = [${(lower * 100).toFixed(2)}%, ${(upper * 100).toFixed(2)}%]</span>
+        <span class="note">ตีความ: เรามั่นใจ ${(confidence * 100).toFixed(1)}% ว่าสัดส่วนประชากรจริงอยู่ในช่วงนี้</span>
+      `;
+      updateChart(phat, se, lower, upper);
+    }
+
+    confInput.addEventListener('input', () => {
+      confText.textContent = `${confInput.value}%`;
+    });
+    successInput.addEventListener('input', calculate);
+    totalInput.addEventListener('input', calculate);
+    methodSelect.addEventListener('change', calculate);
+    confInput.addEventListener('change', calculate);
+    runBtn.addEventListener('click', calculate);
+
+    calculate();
+  </script>
+</body>
+</html>

--- a/prob & Stats/content/19-ci-two-means.html
+++ b/prob & Stats/content/19-ci-two-means.html
@@ -1,0 +1,418 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8" />
+  <title>บทที่ 19: ช่วงความเชื่อมั่นผลต่างค่าเฉลี่ย</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      --accent: #283593;
+      --accent-light: #5c6bc0;
+      --accent-dark: #1a237e;
+      --card-bg: rgba(237, 241, 255, 0.94);
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+      min-height: 100vh;
+      background: radial-gradient(circle at 18% 20%, rgba(92,107,192,0.25), transparent 60%),
+                  radial-gradient(circle at 80% 18%, rgba(40,53,147,0.2), transparent 60%),
+                  linear-gradient(180deg, rgba(232,234,246,0.92), rgba(227,242,253,0.9));
+    }
+    main.container { max-width: 1150px; margin: 0 auto; padding: clamp(2rem, 5vw, 3.5rem); display: grid; gap: 2.3rem; }
+    header.hero {
+      background: linear-gradient(135deg, var(--accent), var(--accent-light));
+      color: #fff;
+      padding: clamp(2.6rem, 6vw, 4rem);
+      border-radius: 32px;
+      position: relative;
+      overflow: hidden;
+      box-shadow: 0 32px 58px rgba(40,53,147,0.22);
+    }
+    header.hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 80% 20%, rgba(255,255,255,0.42), transparent 55%),
+                  radial-gradient(circle at 20% 75%, rgba(255,255,255,0.24), transparent 70%);
+    }
+    header.hero h1 { font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem); margin-bottom: 0.75rem; }
+    header.hero p { font-size: 1.12rem; max-width: 720px; line-height: 1.7; }
+    section.card {
+      background: var(--card-bg);
+      border-radius: 26px;
+      padding: clamp(1.8rem, 4vw, 2.6rem);
+      box-shadow: 0 20px 36px rgba(26,35,126,0.14);
+      backdrop-filter: blur(6px);
+      display: grid;
+      gap: 1.1rem;
+    }
+    section.card h2 {
+      color: var(--accent);
+      font-size: 1.9rem;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin: 0;
+    }
+    .badge { background: rgba(63,81,181,0.12); color: var(--accent-dark); padding: 0.2rem 0.85rem; border-radius: 999px; font-size: 0.88rem; font-weight: 600; }
+    .grid { display: grid; gap: 1.2rem; }
+    @media (min-width: 980px) { .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    article.definition { padding: 1.35rem 1.6rem; border-radius: 20px; background: rgba(227,234,253,0.85); border: 1px solid rgba(40,53,147,0.18); display: grid; gap: 0.6rem; }
+    article.definition strong { color: var(--accent-dark); font-size: 1.05rem; }
+    .highlight { border-left: 6px solid var(--accent); padding: 1rem 1.25rem; background: rgba(40,53,147,0.1); border-radius: 18px; line-height: 1.7; }
+    .calculator { display: grid; gap: 1rem; margin-top: 0.8rem; }
+    .calculator label { font-weight: 600; color: var(--accent-dark); display: grid; gap: 0.4rem; }
+    .calculator input, .calculator select {
+      padding: 0.75rem 1rem;
+      border-radius: 14px;
+      border: 1px solid rgba(63,81,181,0.28);
+      font-size: 1rem;
+      background: rgba(255,255,255,0.95);
+    }
+    .calculator button {
+      background: linear-gradient(135deg, var(--accent-dark), var(--accent));
+      color: #fff;
+      border: 0;
+      border-radius: 14px;
+      padding: 0.85rem 1.2rem;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .calculator button:hover { transform: translateY(-2px); box-shadow: 0 16px 30px rgba(26,35,126,0.22); }
+    .result-card { background: rgba(255,255,255,0.95); border-radius: 20px; padding: 1.2rem 1.4rem; border: 1px solid rgba(63,81,181,0.18); display: grid; gap: 0.6rem; }
+    canvas { background: rgba(255,255,255,0.88); border-radius: 18px; padding: 1rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.6rem 0.75rem; text-align: left; }
+    th { background: rgba(92,107,192,0.12); color: var(--accent-dark); }
+    tr:nth-child(even) { background: rgba(227,234,253,0.6); }
+    .flex { display: grid; gap: 1rem; }
+    @media (min-width: 880px) { .flex { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    .inline { display: flex; align-items: center; gap: 0.5rem; font-size: 0.95rem; }
+  </style>
+</head>
+<body class="page">
+  <main class="container">
+    <header class="hero">
+      <span class="badge">สองประชากรเปรียบเทียบ</span>
+      <h1>บทที่ 19: ช่วงความเชื่อมั่นของผลต่างค่าเฉลี่ยสองประชากร (μ₁ − μ₂)</h1>
+      <p>เปรียบเทียบค่าเฉลี่ยระหว่างสองกลุ่ม เช่น ผลทดสอบก่อนและหลังอบรม หรือระหว่างกลุ่มทดลองกับกลุ่มควบคุม พร้อมตัวช่วยเลือกสูตร (Welch, Pooled, Paired) และการตีความผลลัพธ์.</p>
+    </header>
+
+    <section class="card">
+      <h2>1. รูปแบบของการเปรียบเทียบ</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>สองกลุ่มอิสระ (Independent Samples)</strong>
+          <ul>
+            <li>แต่ละข้อมูลอยู่ในกลุ่มเดียวเท่านั้น</li>
+            <li>ตัวอย่างเป็นอิสระระหว่างกัน</li>
+            <li>ใช้ Welch เมื่อส่วนเบี่ยงเบนมาตรฐานต่างกัน</li>
+          </ul>
+        </article>
+        <article class="definition">
+          <strong>ข้อมูลจับคู่ (Paired)</strong>
+          <ul>
+            <li>วัดคน/หน่วยเดียวกันสองครั้ง หรือจับคู่เป็นคู่</li>
+            <li>คำนวณความแตกต่างต่อคู่ แล้วสร้างช่วงของค่าเฉลี่ยความต่าง</li>
+            <li>ลดความแปรปรวนจากความแตกต่างระหว่างบุคคล</li>
+          </ul>
+        </article>
+      </div>
+      <div class="highlight">
+        <strong>สมมติฐานพื้นฐาน</strong> ทั้งสองกรณีต้องการการสุ่ม, ความเป็นอิสระของตัวอย่าง, และรูปแบบข้อมูลใกล้เคียงปกติ หรือขนาดตัวอย่างใหญ่พอ.
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>2. สูตรสำคัญ</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>Welch (ไม่สมมติความแปรปรวนเท่ากัน)</strong>
+          <p>\[ \bar{x}_1 - \bar{x}_2 \pm t_{\alpha/2, \nu} \sqrt{ \frac{s_1^2}{n_1} + \frac{s_2^2}{n_2} } \]</p>
+          <p>\(\nu\) (องศาอิสระ) คำนวณด้วยสูตร Welch-Satterthwaite.</p>
+        </article>
+        <article class="definition">
+          <strong>Pooled (สันนิษฐานความแปรปรวนเท่ากัน)</strong>
+          <p>\(s_p^2 = \dfrac{(n_1-1)s_1^2 + (n_2-1)s_2^2}{n_1 + n_2 - 2}\)</p>
+          <p>Se = \(s_p \sqrt{\dfrac{1}{n_1} + \dfrac{1}{n_2}}\)</p>
+          <p>ใช้ df = \(n_1 + n_2 - 2\)</p>
+        </article>
+      </div>
+      <div class="highlight">
+        <strong>Paired</strong> คำนวณจากความต่างต่อคู่: \(\bar{d} \pm t_{\alpha/2, n-1} \dfrac{s_d}{\sqrt{n}}\)
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>3. เครื่องคำนวณช่วงความเชื่อมั่นผลต่างค่าเฉลี่ย</h2>
+      <p>เลือกประเภทข้อมูล กรอกสถิติตัวอย่าง แล้วให้ระบบช่วยคำนวณพร้อมกราฟประกอบ.</p>
+      <div class="calculator">
+        <label>ประเภทการเปรียบเทียบ
+          <select id="mode">
+            <option value="independent">สองกลุ่มอิสระ</option>
+            <option value="paired">ข้อมูลจับคู่</option>
+          </select>
+        </label>
+        <div id="independent-fields" class="flex">
+          <div>
+            <label>ค่าเฉลี่ยกลุ่ม 1 (\(\bar{x}_1\))
+              <input type="number" id="mean1" value="72.4" step="0.01" />
+            </label>
+            <label>ส่วนเบี่ยงเบนมาตรฐานกลุ่ม 1 (s₁)
+              <input type="number" id="sd1" value="8.1" step="0.01" min="0" />
+            </label>
+            <label>ขนาดตัวอย่างกลุ่ม 1 (n₁)
+              <input type="number" id="n1" value="28" min="2" />
+            </label>
+          </div>
+          <div>
+            <label>ค่าเฉลี่ยกลุ่ม 2 (\(\bar{x}_2\))
+              <input type="number" id="mean2" value="68.2" step="0.01" />
+            </label>
+            <label>ส่วนเบี่ยงเบนมาตรฐานกลุ่ม 2 (s₂)
+              <input type="number" id="sd2" value="9.4" step="0.01" min="0" />
+            </label>
+            <label>ขนาดตัวอย่างกลุ่ม 2 (n₂)
+              <input type="number" id="n2" value="32" min="2" />
+            </label>
+          </div>
+        </div>
+        <label class="inline" id="pooled-wrapper">
+          <input type="checkbox" id="pooled" />
+          ใช้ความแปรปรวนร่วม (สันนิษฐาน σ₁² ≈ σ₂²)
+        </label>
+        <div id="paired-fields" style="display:none">
+          <label>ค่าเฉลี่ยความแตกต่าง (\(\bar{d}\))
+            <input type="number" id="mean-d" value="4.6" step="0.01" />
+          </label>
+          <label>ส่วนเบี่ยงเบนมาตรฐานของความแตกต่าง (s_d)
+            <input type="number" id="sd-d" value="6.2" step="0.01" min="0" />
+          </label>
+          <label>จำนวนคู่ (n)
+            <input type="number" id="n-d" value="20" min="2" />
+          </label>
+        </div>
+        <label>ระดับความเชื่อมั่น (%)
+          <input type="range" id="conf" min="80" max="99" value="95" />
+        </label>
+        <div class="note">ระดับความเชื่อมั่นปัจจุบัน: <span id="conf-text">95%</span></div>
+        <button id="calc">คำนวณช่วง</button>
+      </div>
+      <div class="result-card" id="summary" style="display:none"></div>
+      <canvas id="diff-chart" height="220"></canvas>
+    </section>
+
+    <section class="card">
+      <h2>4. ตัวอย่างการตีความ</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>สถานการณ์</th>
+            <th>รายละเอียด</th>
+            <th>ช่วง 95%</th>
+            <th>ข้อสรุป</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>คะแนนสอบก่อน-หลัง</td>
+            <td>n=20 (paired), \(\bar{d}=6.1\), s_d=7.3</td>
+            <td>[2.5, 9.7]</td>
+            <td>เฉลี่ยแล้วคะแนนเพิ่มขึ้นอย่างมีนัยสำคัญในช่วง 2.5–9.7 คะแนน</td>
+          </tr>
+          <tr>
+            <td>อัตราการผลิตระหว่างสาย A และ B</td>
+            <td>Welch: \(\bar{x}_1 - \bar{x}_2 = 4.2\), SE=1.8</td>
+            <td>[0.5, 7.9]</td>
+            <td>สาย A น่าจะผลิตได้มากกว่า 0.5–7.9 หน่วย/ชั่วโมง</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="card">
+      <h2>5. Checklist สั้นๆ</h2>
+      <ul>
+        <li>✅ ระบุประเภทตัวอย่างถูกต้อง (อิสระ vs จับคู่)</li>
+        <li>✅ ตรวจสอบความเป็นอิสระและรูปแบบการสุ่ม</li>
+        <li>✅ เงื่อนไขปกติ/ขนาดตัวอย่างเพียงพอ</li>
+        <li>✅ บอกสูตรที่ใช้ (Welch / Pooled / Paired)</li>
+        <li>✅ ตีความผลต่างในบริบท (เช่น “กลุ่ม 1 สูงกว่าโดยเฉลี่ย ...”)</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.5/dist/jstat.min.js"></script>
+  <script>
+    const modeSelect = document.getElementById('mode');
+    const independentFields = document.getElementById('independent-fields');
+    const pairedFields = document.getElementById('paired-fields');
+    const pooledWrapper = document.getElementById('pooled-wrapper');
+    const mean1Input = document.getElementById('mean1');
+    const mean2Input = document.getElementById('mean2');
+    const sd1Input = document.getElementById('sd1');
+    const sd2Input = document.getElementById('sd2');
+    const n1Input = document.getElementById('n1');
+    const n2Input = document.getElementById('n2');
+    const pooledInput = document.getElementById('pooled');
+    const meanDInput = document.getElementById('mean-d');
+    const sdDInput = document.getElementById('sd-d');
+    const nDInput = document.getElementById('n-d');
+    const confInput = document.getElementById('conf');
+    const confText = document.getElementById('conf-text');
+    const calcBtn = document.getElementById('calc');
+    const summary = document.getElementById('summary');
+    const ctx = document.getElementById('diff-chart');
+    let chart;
+
+    function toggleMode() {
+      const mode = modeSelect.value;
+      if (mode === 'paired') {
+        pairedFields.style.display = 'grid';
+        independentFields.style.display = 'none';
+        pooledWrapper.style.display = 'none';
+      } else {
+        pairedFields.style.display = 'none';
+        independentFields.style.display = 'grid';
+        pooledWrapper.style.display = 'flex';
+      }
+    }
+
+    function welchDf(s1, s2, n1, n2) {
+      const t1 = (s1 * s1) / n1;
+      const t2 = (s2 * s2) / n2;
+      const num = Math.pow(t1 + t2, 2);
+      const den = (Math.pow(t1, 2) / (n1 - 1)) + (Math.pow(t2, 2) / (n2 - 1));
+      return num / den;
+    }
+
+    function updateChart(mean, se, lower, upper, label) {
+      const points = 200;
+      const range = 6 * se;
+      const start = mean - range / 2;
+      const end = mean + range / 2;
+      const labels = [];
+      const base = [];
+      const highlight = [];
+      for (let i = 0; i <= points; i += 1) {
+        const x = start + ((end - start) * i) / points;
+        const std = (x - mean) / (se || 1e-6);
+        const density = jStat.normal.pdf(std, 0, 1) / (se || 1e-6);
+        labels.push(x.toFixed(3));
+        base.push(density);
+        highlight.push(x >= lower && x <= upper ? density : null);
+      }
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: label,
+              data: base,
+              borderColor: 'rgba(40,53,147,0.45)',
+              borderWidth: 2,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: false
+            },
+            {
+              label: 'ช่วงความเชื่อมั่น',
+              data: highlight,
+              borderColor: 'rgba(92,107,192,0.95)',
+              backgroundColor: 'rgba(92,107,192,0.35)',
+              borderWidth: 2.4,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: true
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { labels: { color: '#1a237e' } } },
+          scales: {
+            x: { title: { display: true, text: 'ผลต่างค่าเฉลี่ย (μ₁ − μ₂)', color: '#1a237e' }, ticks: { color: '#1a237e' } },
+            y: { title: { display: true, text: 'ความหนาแน่นโดยประมาณ', color: '#1a237e' }, ticks: { color: '#1a237e' } }
+          }
+        }
+      });
+    }
+
+    function calculate() {
+      const confidence = parseInt(confInput.value, 10) / 100;
+      confText.textContent = `${(confidence * 100).toFixed(0)}%`;
+      const alpha = 1 - confidence;
+      let diffMean;
+      let se;
+      let df;
+      let methodLabel;
+
+      if (modeSelect.value === 'paired') {
+        const meanD = parseFloat(meanDInput.value);
+        const sdD = Math.max(parseFloat(sdDInput.value), 0.00001);
+        const n = Math.max(parseInt(nDInput.value, 10), 2);
+        nDInput.value = n;
+        diffMean = meanD;
+        se = sdD / Math.sqrt(n);
+        df = n - 1;
+        methodLabel = 'Paired t';
+      } else {
+        const mean1 = parseFloat(mean1Input.value);
+        const mean2 = parseFloat(mean2Input.value);
+        const sd1 = Math.max(parseFloat(sd1Input.value), 0.00001);
+        const sd2 = Math.max(parseFloat(sd2Input.value), 0.00001);
+        const n1 = Math.max(parseInt(n1Input.value, 10), 2);
+        const n2 = Math.max(parseInt(n2Input.value, 10), 2);
+        n1Input.value = n1;
+        n2Input.value = n2;
+        diffMean = mean1 - mean2;
+        if (pooledInput.checked) {
+          const sp2 = (((n1 - 1) * sd1 * sd1) + ((n2 - 1) * sd2 * sd2)) / (n1 + n2 - 2);
+          const sp = Math.sqrt(sp2);
+          se = sp * Math.sqrt(1 / n1 + 1 / n2);
+          df = n1 + n2 - 2;
+          methodLabel = 'Pooled t';
+        } else {
+          se = Math.sqrt((sd1 * sd1) / n1 + (sd2 * sd2) / n2);
+          df = welchDf(sd1, sd2, n1, n2);
+          methodLabel = 'Welch t';
+        }
+      }
+
+      const tCrit = jStat.studentt.inv(1 - alpha / 2, df);
+      const margin = tCrit * se;
+      const lower = diffMean - margin;
+      const upper = diffMean + margin;
+
+      summary.style.display = 'grid';
+      summary.innerHTML = `
+        <strong>ผลลัพธ์</strong>
+        <span>ผลต่างค่าเฉลี่ย = ${diffMean.toFixed(3)}</span>
+        <span>SE = ${se.toFixed(3)} | df ≈ ${df.toFixed(2)} | t_{\alpha/2} = ${tCrit.toFixed(3)}</span>
+        <span>ช่วงความเชื่อมั่น (${methodLabel}) = [${lower.toFixed(3)}, ${upper.toFixed(3)}]</span>
+        <span class="note">ตีความ: เรามั่นใจ ${(confidence * 100).toFixed(1)}% ว่าผลต่างค่าเฉลี่ยจริงอยู่ในช่วงนี้</span>
+      `;
+
+      updateChart(diffMean, se, lower, upper, methodLabel);
+    }
+
+    modeSelect.addEventListener('change', () => {
+      toggleMode();
+      calculate();
+    });
+    confInput.addEventListener('input', () => { confText.textContent = `${confInput.value}%`; });
+    [mean1Input, mean2Input, sd1Input, sd2Input, n1Input, n2Input, pooledInput, meanDInput, sdDInput, nDInput].forEach(el => {
+      if (!el) return;
+      el.addEventListener('input', calculate);
+    });
+    confInput.addEventListener('change', calculate);
+    calcBtn.addEventListener('click', calculate);
+
+    toggleMode();
+    calculate();
+  </script>
+</body>
+</html>

--- a/prob & Stats/content/20-ci-two-proportions.html
+++ b/prob & Stats/content/20-ci-two-proportions.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8" />
+  <title>บทที่ 20: ช่วงความเชื่อมั่นผลต่างสัดส่วน</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      --accent: #c62828;
+      --accent-light: #ef5350;
+      --accent-dark: #b71c1c;
+      --card-bg: rgba(255, 235, 238, 0.94);
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+      min-height: 100vh;
+      background: radial-gradient(circle at 15% 20%, rgba(239,83,80,0.28), transparent 60%),
+                  radial-gradient(circle at 80% 18%, rgba(198,40,40,0.18), transparent 60%),
+                  linear-gradient(180deg, rgba(255,235,238,0.92), rgba(255,245,245,0.9));
+    }
+    main.container { max-width: 1120px; margin: 0 auto; padding: clamp(2rem, 5vw, 3.5rem); display: grid; gap: 2.2rem; }
+    header.hero { background: linear-gradient(135deg, var(--accent), var(--accent-light)); color: #fff; padding: clamp(2.6rem, 6vw, 4rem); border-radius: 32px; position: relative; overflow: hidden; box-shadow: 0 32px 54px rgba(198,40,40,0.22); }
+    header.hero::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 80% 18%, rgba(255,255,255,0.45), transparent 55%), radial-gradient(circle at 20% 75%, rgba(255,255,255,0.24), transparent 70%); }
+    header.hero h1 { font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem); margin-bottom: 0.75rem; }
+    header.hero p { font-size: 1.12rem; max-width: 720px; line-height: 1.7; }
+    section.card { background: var(--card-bg); border-radius: 26px; padding: clamp(1.8rem, 4vw, 2.6rem); box-shadow: 0 20px 36px rgba(183,28,28,0.12); backdrop-filter: blur(6px); display: grid; gap: 1.1rem; }
+    section.card h2 { color: var(--accent); font-size: 1.9rem; display: flex; align-items: center; gap: 0.75rem; margin: 0; }
+    .badge { background: rgba(183,28,28,0.12); color: var(--accent-dark); padding: 0.2rem 0.8rem; border-radius: 999px; font-size: 0.9rem; font-weight: 600; }
+    .grid { display: grid; gap: 1.2rem; }
+    @media (min-width: 960px) { .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    article.definition { padding: 1.35rem 1.6rem; border-radius: 20px; background: rgba(255,205,210,0.85); border: 1px solid rgba(198,40,40,0.18); display: grid; gap: 0.6rem; }
+    article.definition strong { color: var(--accent-dark); font-size: 1.05rem; }
+    .highlight { border-left: 6px solid var(--accent); padding: 1rem 1.25rem; background: rgba(229,57,53,0.12); border-radius: 18px; line-height: 1.7; }
+    .calculator { display: grid; gap: 1rem; margin-top: 0.8rem; }
+    .calculator label { font-weight: 600; color: var(--accent-dark); display: grid; gap: 0.4rem; }
+    .calculator input, .calculator select { padding: 0.75rem 1rem; border-radius: 14px; border: 1px solid rgba(198,40,40,0.28); font-size: 1rem; background: rgba(255,255,255,0.95); }
+    .calculator button { background: linear-gradient(135deg, var(--accent-dark), var(--accent)); color: #fff; border: 0; border-radius: 14px; padding: 0.85rem 1.2rem; font-size: 1rem; font-weight: 600; cursor: pointer; transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .calculator button:hover { transform: translateY(-2px); box-shadow: 0 16px 30px rgba(198,40,40,0.2); }
+    .result-card { background: rgba(255,255,255,0.95); border-radius: 20px; padding: 1.2rem 1.4rem; border: 1px solid rgba(229,57,53,0.18); display: grid; gap: 0.6rem; }
+    canvas { background: rgba(255,255,255,0.88); border-radius: 18px; padding: 1rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.6rem 0.75rem; text-align: left; }
+    th { background: rgba(229,57,53,0.12); color: var(--accent-dark); }
+    tr:nth-child(even) { background: rgba(255,205,210,0.6); }
+  </style>
+</head>
+<body class="page">
+  <main class="container">
+    <header class="hero">
+      <span class="badge">Difference in Proportions</span>
+      <h1>บทที่ 20: ช่วงความเชื่อมั่นของผลต่างสัดส่วนสองประชากร (p₁ − p₂)</h1>
+      <p>เปรียบเทียบอัตราหรือสัดส่วนระหว่างสองกลุ่ม เช่น ความพึงพอใจของลูกค้าในสองสาขา หรือเปอร์เซ็นต์ผู้ตอบรับการรักษาในสองวิธีการ.</p>
+    </header>
+
+    <section class="card">
+      <h2>1. แนวคิดและเงื่อนไข</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>ผลต่างสัดส่วน</strong>
+          <p>\(p_1 - p_2\) บอกส่วนต่างของสัดส่วนประชากรสองกลุ่ม เราประมาณด้วย \(\hat{p}_1 - \hat{p}_2\) โดย \(\hat{p}_i = x_i / n_i\).</p>
+          <ul>
+            <li>ข้อมูลทุกรายการเป็น binary (สำเร็จ/ล้มเหลว)</li>
+            <li>ตัวอย่างของแต่ละกลุ่มเป็นอิสระกัน</li>
+            <li>เงื่อนไขขนาดตัวอย่าง: \(n_i \hat{p}_i ≥ 10\) และ \(n_i(1-\hat{p}_i) ≥ 10\)</li>
+          </ul>
+        </article>
+        <article class="definition">
+          <strong>สูตรมาตรฐาน</strong>
+          <p>\[
+            (\hat{p}_1 - \hat{p}_2) \pm z_{\alpha/2} \sqrt{ \dfrac{\hat{p}_1(1-\hat{p}_1)}{n_1} + \dfrac{\hat{p}_2(1-\hat{p}_2)}{n_2} }
+          \]</p>
+          <p>ใช้ z-critical เนื่องจากผลต่างของสัดส่วนมีการแจกแจงใกล้ปกติเมื่อขนาดตัวอย่างเพียงพอ.</p>
+        </article>
+      </div>
+      <div class="highlight">
+        <strong>หมายเหตุ</strong> ช่วงที่ได้อาจเกินขอบเขต [-1, 1] ในบางกรณี หากต้องการช่วงที่คุมค่าสมดุลยิ่งขึ้นให้ใช้ Newcombe หรือ Wilson-based approaches.
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>2. เครื่องคำนวณช่วงความเชื่อมั่นผลต่างสัดส่วน</h2>
+      <p>กรอกจำนวนสำเร็จและขนาดตัวอย่างของทั้งสองกลุ่มเพื่อสร้างช่วง พร้อมดูกราฟประกอบการตีความ.</p>
+      <div class="calculator">
+        <div class="grid two">
+          <div>
+            <label>จำนวนสำเร็จในกลุ่ม 1 (x₁)
+              <input type="number" id="x1" value="120" min="0" />
+            </label>
+            <label>ขนาดตัวอย่างกลุ่ม 1 (n₁)
+              <input type="number" id="n1" value="300" min="1" />
+            </label>
+          </div>
+          <div>
+            <label>จำนวนสำเร็จในกลุ่ม 2 (x₂)
+              <input type="number" id="x2" value="95" min="0" />
+            </label>
+            <label>ขนาดตัวอย่างกลุ่ม 2 (n₂)
+              <input type="number" id="n2" value="260" min="1" />
+            </label>
+          </div>
+        </div>
+        <label>ระดับความเชื่อมั่น (%)
+          <input type="range" id="conf" min="80" max="99" value="95" />
+        </label>
+        <div class="note">ระดับความเชื่อมั่นปัจจุบัน: <span id="conf-text">95%</span></div>
+        <button id="calc">คำนวณช่วง</button>
+      </div>
+      <div class="result-card" id="summary" style="display:none"></div>
+      <canvas id="diff-chart" height="220"></canvas>
+    </section>
+
+    <section class="card">
+      <h2>3. การตีความผลลัพธ์</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>สถานการณ์</th>
+            <th>ข้อมูล</th>
+            <th>ช่วง 95%</th>
+            <th>ข้อสรุป</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>ยอดผู้ตอบรับโปรโมชั่น A vs B</td>
+            <td>\(\hat{p}_1=0.40, \hat{p}_2=0.32\)</td>
+            <td>[0.02, 0.14]</td>
+            <td>กลุ่ม A น่าจะมีอัตราตอบรับมากกว่า 2–14 จุดเปอร์เซ็นต์</td>
+          </tr>
+          <tr>
+            <td>อัตราการหายของยาใหม่เทียบมาตรฐาน</td>
+            <td>\(\hat{p}_1=0.78, \hat{p}_2=0.71\)</td>
+            <td>[-0.01, 0.15]</td>
+            <td>ช่วงครอบคลุม 0 → ยังไม่สามารถสรุปว่ายาใหม่ดีกว่าอย่างมีนัยสำคัญ</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="card">
+      <h2>4. Checklist ก่อนรายงาน</h2>
+      <ul>
+        <li>✅ ตัวอย่างของแต่ละกลุ่มสุ่มและเป็นอิสระ</li>
+        <li>✅ เงื่อนไข \(n_i\hat{p}_i\) และ \(n_i(1-\hat{p}_i)\) ผ่าน</li>
+        <li>✅ ระบุวิธีการและระดับความเชื่อมั่น</li>
+        <li>✅ ตีความในรูป “ความแตกต่างของอัตรา/เปอร์เซ็นต์”</li>
+        <li>✅ ชี้ว่าช่วงครอบคลุม 0 หรือไม่ (เกี่ยวข้องกับการทดสอบสมมติฐาน)</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.5/dist/jstat.min.js"></script>
+  <script>
+    const x1Input = document.getElementById('x1');
+    const n1Input = document.getElementById('n1');
+    const x2Input = document.getElementById('x2');
+    const n2Input = document.getElementById('n2');
+    const confInput = document.getElementById('conf');
+    const confText = document.getElementById('conf-text');
+    const calcBtn = document.getElementById('calc');
+    const summary = document.getElementById('summary');
+    const ctx = document.getElementById('diff-chart');
+    let chart;
+
+    function updateChart(mean, se, lower, upper) {
+      const points = 200;
+      const range = 6 * se;
+      const start = mean - range / 2;
+      const end = mean + range / 2;
+      const labels = [];
+      const base = [];
+      const highlight = [];
+      for (let i = 0; i <= points; i += 1) {
+        const x = start + ((end - start) * i) / points;
+        const std = (x - mean) / (se || 1e-6);
+        const density = jStat.normal.pdf(std, 0, 1) / (se || 1e-6);
+        labels.push(x.toFixed(3));
+        base.push(density);
+        highlight.push(x >= lower && x <= upper ? density : null);
+      }
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Sampling distribution approx',
+              data: base,
+              borderColor: 'rgba(198,40,40,0.45)',
+              borderWidth: 2,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: false
+            },
+            {
+              label: 'ช่วงความเชื่อมั่น',
+              data: highlight,
+              borderColor: 'rgba(239,83,80,0.95)',
+              backgroundColor: 'rgba(239,83,80,0.35)',
+              borderWidth: 2.4,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: true
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { labels: { color: '#b71c1c' } } },
+          scales: {
+            x: { title: { display: true, text: 'ผลต่างสัดส่วน (p₁ − p₂)', color: '#b71c1c' }, ticks: { color: '#b71c1c' } },
+            y: { title: { display: true, text: 'ความหนาแน่นโดยประมาณ', color: '#b71c1c' }, ticks: { color: '#b71c1c' } }
+          }
+        }
+      });
+    }
+
+    function calculate() {
+      const x1 = Math.max(parseInt(x1Input.value, 10), 0);
+      const n1 = Math.max(parseInt(n1Input.value, 10), 1);
+      const x2 = Math.max(parseInt(x2Input.value, 10), 0);
+      const n2 = Math.max(parseInt(n2Input.value, 10), 1);
+      const confidence = parseInt(confInput.value, 10) / 100;
+      const alpha = 1 - confidence;
+      const z = jStat.normal.inv(1 - alpha / 2, 0, 1);
+      const p1 = x1 / n1;
+      const p2 = x2 / n2;
+      const diff = p1 - p2;
+      const se = Math.sqrt((p1 * (1 - p1)) / n1 + (p2 * (1 - p2)) / n2);
+      const margin = z * se;
+      const lower = diff - margin;
+      const upper = diff + margin;
+
+      summary.style.display = 'grid';
+      summary.innerHTML = `
+        <strong>ผลลัพธ์</strong>
+        <span>\u005Chat{p}_1 = ${(p1 * 100).toFixed(2)}% (${x1}/${n1}) | \u005Chat{p}_2 = ${(p2 * 100).toFixed(2)}% (${x2}/${n2})</span>
+        <span>ผลต่างตัวอย่าง = ${(diff * 100).toFixed(2)} จุดเปอร์เซ็นต์</span>
+        <span>ระดับความเชื่อมั่น ${(confidence * 100).toFixed(1)}% | z_{\alpha/2} = ${z.toFixed(3)}</span>
+        <span>ช่วงความเชื่อมั่น = [${(lower * 100).toFixed(2)}, ${(upper * 100).toFixed(2)}] จุดเปอร์เซ็นต์</span>
+        <span class="note">ตีความ: เรามั่นใจ ${(confidence * 100).toFixed(1)}% ว่าผลต่างสัดส่วนจริงอยู่ในช่วงนี้</span>
+      `;
+
+      updateChart(diff, se, lower, upper);
+    }
+
+    confInput.addEventListener('input', () => { confText.textContent = `${confInput.value}%`; });
+    [x1Input, n1Input, x2Input, n2Input].forEach(el => el.addEventListener('input', calculate));
+    confInput.addEventListener('change', calculate);
+    calcBtn.addEventListener('click', calculate);
+
+    calculate();
+  </script>
+</body>
+</html>

--- a/prob & Stats/content/21-sample-size.html
+++ b/prob & Stats/content/21-sample-size.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8" />
+  <title>บทที่ 21: การคำนวณขนาดตัวอย่าง</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      --accent: #0277bd;
+      --accent-light: #29b6f6;
+      --accent-dark: #01579b;
+      --card-bg: rgba(227, 242, 253, 0.94);
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+      min-height: 100vh;
+      background: radial-gradient(circle at 18% 22%, rgba(41, 182, 246, 0.28), transparent 60%),
+                  radial-gradient(circle at 80% 18%, rgba(2, 119, 189, 0.2), transparent 60%),
+                  linear-gradient(180deg, rgba(225, 245, 254, 0.92), rgba(232, 245, 255, 0.9));
+    }
+    main.container { max-width: 1120px; margin: 0 auto; padding: clamp(2rem, 5vw, 3.5rem); display: grid; gap: 2.2rem; }
+    header.hero { background: linear-gradient(135deg, var(--accent), var(--accent-light)); color: #fff; padding: clamp(2.6rem, 6vw, 4rem); border-radius: 32px; position: relative; overflow: hidden; box-shadow: 0 32px 54px rgba(2, 119, 189, 0.25); }
+    header.hero::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 78% 18%, rgba(255,255,255,0.45), transparent 55%), radial-gradient(circle at 20% 75%, rgba(255,255,255,0.24), transparent 70%); }
+    header.hero h1 { font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem); margin-bottom: 0.75rem; }
+    header.hero p { font-size: 1.12rem; max-width: 720px; line-height: 1.7; }
+    section.card { background: var(--card-bg); border-radius: 26px; padding: clamp(1.8rem, 4vw, 2.6rem); box-shadow: 0 20px 36px rgba(1, 87, 155, 0.16); backdrop-filter: blur(6px); display: grid; gap: 1.1rem; }
+    section.card h2 { color: var(--accent); font-size: 1.9rem; display: flex; align-items: center; gap: 0.75rem; margin: 0; }
+    .badge { background: rgba(2, 119, 189, 0.12); color: var(--accent-dark); padding: 0.2rem 0.8rem; border-radius: 999px; font-size: 0.9rem; font-weight: 600; }
+    .grid { display: grid; gap: 1.2rem; }
+    @media (min-width: 960px) { .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    article.definition { padding: 1.35rem 1.6rem; border-radius: 20px; background: rgba(187, 222, 251, 0.85); border: 1px solid rgba(2, 119, 189, 0.18); display: grid; gap: 0.6rem; }
+    article.definition strong { color: var(--accent-dark); font-size: 1.05rem; }
+    .highlight { border-left: 6px solid var(--accent); padding: 1rem 1.25rem; background: rgba(2, 136, 209, 0.12); border-radius: 18px; line-height: 1.7; }
+    .calculator { display: grid; gap: 1rem; margin-top: 0.8rem; }
+    .calculator label { font-weight: 600; color: var(--accent-dark); display: grid; gap: 0.4rem; }
+    .calculator input, .calculator select {
+      padding: 0.75rem 1rem;
+      border-radius: 14px;
+      border: 1px solid rgba(2, 119, 189, 0.28);
+      font-size: 1rem;
+      background: rgba(255,255,255,0.95);
+    }
+    .calculator button {
+      background: linear-gradient(135deg, var(--accent-dark), var(--accent));
+      color: #fff;
+      border: 0;
+      border-radius: 14px;
+      padding: 0.85rem 1.2rem;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .calculator button:hover { transform: translateY(-2px); box-shadow: 0 16px 30px rgba(1, 87, 155, 0.24); }
+    .result-card { background: rgba(255,255,255,0.95); border-radius: 20px; padding: 1.2rem 1.4rem; border: 1px solid rgba(2, 136, 209, 0.2); display: grid; gap: 0.6rem; }
+    canvas { background: rgba(255,255,255,0.88); border-radius: 18px; padding: 1rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.6rem 0.75rem; text-align: left; }
+    th { background: rgba(187, 222, 251, 0.5); color: var(--accent-dark); }
+    tr:nth-child(even) { background: rgba(227, 242, 253, 0.6); }
+  </style>
+</head>
+<body class="page">
+  <main class="container">
+    <header class="hero">
+      <span class="badge">Design Stage</span>
+      <h1>บทที่ 21: การคำนวณขนาดตัวอย่าง (Sample Size Determination)</h1>
+      <p>กำหนดจำนวนตัวอย่างที่เหมาะสมเพื่อให้การประมาณหรือการทดสอบสมมติฐานมีพลังและความแม่นยำตามต้องการ พร้อมเครื่องคิดเลขที่ช่วยเชื่อมโยงระหว่างความเชื่อมั่น ขอบเขตผิดพลาด และพลังการทดสอบ.</p>
+    </header>
+
+    <section class="card">
+      <h2>1. ปัจจัยที่ต้องพิจารณา</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>ระดับความเชื่อมั่น / ความเสี่ยง (α)</strong>
+          <p>ความต้องการความเชื่อมั่นสูง → ต้องการตัวอย่างมากขึ้น เพราะช่วงความเชื่อมั่นหรือพลังการทดสอบต้องครอบคลุมความไม่แน่นอนมากขึ้น</p>
+        </article>
+        <article class="definition">
+          <strong>ขอบเขตผิดพลาดที่ยอมรับได้ (E)</strong>
+          <p>ต้องการความละเอียดสูง (E เล็ก) → ต้องใช้ตัวอย่างเพิ่มขึ้น เพื่อให้ช่วงความเชื่อมั่นแคบลง</p>
+        </article>
+      </div>
+      <div class="highlight">
+        <strong>องค์ประกอบอื่นๆ</strong> เช่น ความแปรปรวนของข้อมูล (σ หรือ p(1-p)) และพลังการทดสอบ (1-β) หากออกแบบสำหรับการทดสอบสมมติฐาน
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>2. สูตรพื้นฐาน</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>สำหรับค่าเฉลี่ย</strong>
+          <p>\[ n = \left( \dfrac{z_{\alpha/2}\, \sigma}{E} \right)^2 \]</p>
+          <p>เมื่อไม่รู้ σ ให้ใช้ค่าประมาณจากข้อมูลก่อนหน้า หรือใช้ s ของตัวอย่างนำร่อง</p>
+        </article>
+        <article class="definition">
+          <strong>สำหรับสัดส่วน</strong>
+          <p>\[ n = \dfrac{z_{\alpha/2}^2 p(1-p)}{E^2} \]</p>
+          <p>หากไม่รู้ p ให้ใช้ 0.5 (กรณีรุนแรงที่สุด) เพื่อให้ได้ขนาดตัวอย่างสูงสุด</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>3. เครื่องคิดเลขขนาดตัวอย่าง</h2>
+      <p>เลือกประเภทปริมาณ เลือกค่าที่ต้องการ แล้วระบบจะคำนวณ n พร้อมแสดงการเปลี่ยนแปลงเมื่อปรับพารามิเตอร์.</p>
+      <div class="calculator">
+        <label>ประเภทการออกแบบ
+          <select id="mode">
+            <option value="mean">ค่าเฉลี่ย (μ)</option>
+            <option value="prop">สัดส่วน (p)</option>
+          </select>
+        </label>
+        <label>ระดับความเชื่อมั่น (%)
+          <input type="range" id="conf" min="80" max="99" value="95" />
+        </label>
+        <div class="note">ระดับความเชื่อมั่น: <span id="conf-text">95%</span></div>
+        <label id="sigma-label">ส่วนเบี่ยงเบนมาตรฐาน (σ)
+          <input type="number" id="sigma" value="12" step="0.01" min="0" />
+        </label>
+        <label id="p-label" style="display:none">ประมาณการสัดส่วน (p)
+          <input type="number" id="phat" value="0.5" step="0.01" min="0" max="1" />
+        </label>
+        <label>ขอบเขตผิดพลาดสูงสุดที่ยอมรับ (E)
+          <input type="number" id="margin" value="3" step="0.01" min="0.0001" />
+        </label>
+        <button id="calc">คำนวณขนาดตัวอย่าง</button>
+      </div>
+      <div class="result-card" id="summary" style="display:none"></div>
+      <canvas id="ss-chart" height="220"></canvas>
+    </section>
+
+    <section class="card">
+      <h2>4. ตารางเปรียบเทียบอย่างรวดเร็ว</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>กรณีศึกษา</th>
+            <th>พารามิเตอร์</th>
+            <th>ขนาดตัวอย่างที่ต้องการ</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>สำรวจคะแนนความพึงพอใจ (σ ≈ 8, E = 1.5, 95%)</td>
+            <td>z = 1.96</td>
+            <td>≈ 109 คน</td>
+          </tr>
+          <tr>
+            <td>สำรวจอัตราผู้ใช้ฟีเจอร์ใหม่ (p ≈ 0.4, E = 0.05, 95%)</td>
+            <td>z = 1.96</td>
+            <td>≈ 369 ตัวอย่าง</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="card">
+      <h2>5. Checklist ก่อนเก็บข้อมูล</h2>
+      <ul>
+        <li>✅ ระบุวัตถุประสงค์ชัดเจน (ประมาณค่า / ทดสอบ)</li>
+        <li>✅ เลือกระดับความเชื่อมั่นและพลังการทดสอบ</li>
+        <li>✅ มีการประมาณ σ หรือ p จากข้อมูลเดิม/นำร่อง</li>
+        <li>✅ พิจารณาอัตราการสูญหายของตัวอย่าง (non-response)</li>
+        <li>✅ เพิ่มตัวอย่างเผื่อการวิเคราะห์ย่อย (subgroup)</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.5/dist/jstat.min.js"></script>
+  <script>
+    const modeSelect = document.getElementById('mode');
+    const confInput = document.getElementById('conf');
+    const confText = document.getElementById('conf-text');
+    const sigmaRow = document.getElementById('sigma-label');
+    const sigmaInput = document.getElementById('sigma');
+    const pRow = document.getElementById('p-label');
+    const pInput = document.getElementById('phat');
+    const marginInput = document.getElementById('margin');
+    const calcBtn = document.getElementById('calc');
+    const summary = document.getElementById('summary');
+    const ctx = document.getElementById('ss-chart');
+    let chart;
+
+    function toggleFields() {
+      if (modeSelect.value === 'mean') {
+        sigmaRow.style.display = 'grid';
+        pRow.style.display = 'none';
+      } else {
+        sigmaRow.style.display = 'none';
+        pRow.style.display = 'grid';
+      }
+    }
+
+    function updateChart(baseValue, z, type) {
+      const points = 20;
+      const labels = [];
+      const data = [];
+      for (let i = 1; i <= points; i += 1) {
+        const margin = baseValue / (i * 0.3 + 0.7);
+        let n;
+        if (type === 'mean') {
+          n = Math.pow((z * sigmaInput.value) / margin, 2);
+        } else {
+          const p = pInput.value;
+          n = (z * z * p * (1 - p)) / (margin * margin);
+        }
+        labels.push((margin).toFixed(2));
+        data.push(Math.ceil(n));
+      }
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [{
+            label: 'n ที่ต้องการเมื่อปรับ E',
+            data,
+            borderColor: 'rgba(2,119,189,0.85)',
+            backgroundColor: 'rgba(41,182,246,0.3)',
+            borderWidth: 2,
+            pointRadius: 4,
+            fill: true,
+            tension: 0.25
+          }]
+        },
+        options: {
+          plugins: { legend: { labels: { color: '#01579b' } } },
+          scales: {
+            x: { title: { display: true, text: 'ขอบเขตผิดพลาด (E)', color: '#01579b' }, ticks: { color: '#01579b' } },
+            y: { title: { display: true, text: 'ขนาดตัวอย่างโดยประมาณ', color: '#01579b' }, ticks: { color: '#01579b' } }
+          }
+        }
+      });
+    }
+
+    function calculate() {
+      const confidence = parseInt(confInput.value, 10) / 100;
+      confText.textContent = `${(confidence * 100).toFixed(0)}%`;
+      const alpha = 1 - confidence;
+      const z = jStat.normal.inv(1 - alpha / 2, 0, 1);
+      const E = Math.max(parseFloat(marginInput.value), 1e-6);
+      let n;
+      let detail;
+      if (modeSelect.value === 'mean') {
+        const sigma = Math.max(parseFloat(sigmaInput.value), 1e-6);
+        n = Math.pow((z * sigma) / E, 2);
+        detail = `z = ${z.toFixed(3)}, σ = ${sigma.toFixed(3)}, E = ${E.toFixed(3)}`;
+      } else {
+        const p = Math.min(Math.max(parseFloat(pInput.value), 0), 1);
+        pInput.value = p;
+        n = (z * z * p * (1 - p)) / (E * E);
+        detail = `z = ${z.toFixed(3)}, p = ${p.toFixed(3)}, E = ${E.toFixed(3)}`;
+      }
+      const nCeil = Math.ceil(n);
+      summary.style.display = 'grid';
+      summary.innerHTML = `
+        <strong>ขนาดตัวอย่างที่ต้องการ</strong>
+        <span>${modeSelect.value === 'mean' ? 'สำหรับค่าเฉลี่ย' : 'สำหรับสัดส่วน'}: n = ${n.toFixed(2)} → ปัดขึ้นเป็น ${nCeil}</span>
+        <span>${detail}</span>
+        <span class="note">เพิ่มตัวอย่างเผื่อข้อมูลสูญหายหรือกรณีวิเคราะห์ย่อยประมาณ 5–15%</span>
+      `;
+
+      updateChart(E, z, modeSelect.value);
+    }
+
+    modeSelect.addEventListener('change', () => {
+      toggleFields();
+      calculate();
+    });
+    confInput.addEventListener('input', () => { confText.textContent = `${confInput.value}%`; });
+    [sigmaInput, pInput, marginInput].forEach(el => el.addEventListener('input', calculate));
+    confInput.addEventListener('change', calculate);
+    calcBtn.addEventListener('click', calculate);
+
+    toggleFields();
+    calculate();
+  </script>
+</body>
+</html>

--- a/prob & Stats/content/22-ci-variance.html
+++ b/prob & Stats/content/22-ci-variance.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8" />
+  <title>บทที่ 22: ช่วงความเชื่อมั่นสำหรับความแปรปรวน</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      --accent: #6a1b9a;
+      --accent-light: #ba68c8;
+      --accent-dark: #4a148c;
+      --card-bg: rgba(243, 229, 245, 0.94);
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+      min-height: 100vh;
+      background: radial-gradient(circle at 15% 18%, rgba(186,104,200,0.28), transparent 60%),
+                  radial-gradient(circle at 80% 18%, rgba(106,27,154,0.22), transparent 60%),
+                  linear-gradient(180deg, rgba(237,231,246,0.92), rgba(243,229,245,0.9));
+    }
+    main.container { max-width: 1120px; margin: 0 auto; padding: clamp(2rem, 5vw, 3.5rem); display: grid; gap: 2.2rem; }
+    header.hero { background: linear-gradient(135deg, var(--accent), var(--accent-light)); color: #fff; padding: clamp(2.6rem, 6vw, 4rem); border-radius: 32px; position: relative; overflow: hidden; box-shadow: 0 32px 54px rgba(74,20,140,0.22); }
+    header.hero::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 80% 20%, rgba(255,255,255,0.45), transparent 55%), radial-gradient(circle at 20% 75%, rgba(255,255,255,0.24), transparent 70%); }
+    header.hero h1 { font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem); margin-bottom: 0.75rem; }
+    header.hero p { font-size: 1.12rem; max-width: 720px; line-height: 1.7; }
+    section.card { background: var(--card-bg); border-radius: 26px; padding: clamp(1.8rem, 4vw, 2.6rem); box-shadow: 0 20px 36px rgba(74,20,140,0.14); backdrop-filter: blur(6px); display: grid; gap: 1.1rem; }
+    section.card h2 { color: var(--accent); font-size: 1.9rem; display: flex; align-items: center; gap: 0.75rem; margin: 0; }
+    .badge { background: rgba(123,31,162,0.12); color: var(--accent-dark); padding: 0.2rem 0.85rem; border-radius: 999px; font-size: 0.9rem; font-weight: 600; }
+    .grid { display: grid; gap: 1.2rem; }
+    @media (min-width: 960px) { .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    article.definition { padding: 1.35rem 1.6rem; border-radius: 20px; background: rgba(225,190,231,0.85); border: 1px solid rgba(106,27,154,0.18); display: grid; gap: 0.6rem; }
+    article.definition strong { color: var(--accent-dark); font-size: 1.05rem; }
+    .highlight { border-left: 6px solid var(--accent); padding: 1rem 1.25rem; background: rgba(142,36,170,0.12); border-radius: 18px; line-height: 1.7; }
+    .calculator { display: grid; gap: 1rem; margin-top: 0.8rem; }
+    .calculator label { font-weight: 600; color: var(--accent-dark); display: grid; gap: 0.4rem; }
+    .calculator input, .calculator select { padding: 0.75rem 1rem; border-radius: 14px; border: 1px solid rgba(123,31,162,0.28); font-size: 1rem; background: rgba(255,255,255,0.95); }
+    .calculator button { background: linear-gradient(135deg, var(--accent-dark), var(--accent)); color: #fff; border: 0; border-radius: 14px; padding: 0.85rem 1.2rem; font-size: 1rem; font-weight: 600; cursor: pointer; transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .calculator button:hover { transform: translateY(-2px); box-shadow: 0 16px 30px rgba(74,20,140,0.18); }
+    .result-card { background: rgba(255,255,255,0.95); border-radius: 20px; padding: 1.2rem 1.4rem; border: 1px solid rgba(142,36,170,0.18); display: grid; gap: 0.6rem; }
+    canvas { background: rgba(255,255,255,0.88); border-radius: 18px; padding: 1rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.6rem 0.75rem; text-align: left; }
+    th { background: rgba(186,104,200,0.16); color: var(--accent-dark); }
+    tr:nth-child(even) { background: rgba(225,190,231,0.6); }
+  </style>
+</head>
+<body class="page">
+  <main class="container">
+    <header class="hero">
+      <span class="badge">Chi-square Interval</span>
+      <h1>บทที่ 22: ช่วงความเชื่อมั่นสำหรับความแปรปรวนและส่วนเบี่ยงเบนมาตรฐาน (σ² / σ)</h1>
+      <p>ใช้การแจกแจงไคสแควร์เพื่อประเมินความไม่แน่นอนของความแปรปรวนในประชากร เหมาะสำหรับข้อมูลเชิงปริมาณที่มาจากประชากรปกติ.</p>
+    </header>
+
+    <section class="card">
+      <h2>1. เงื่อนไขและแนวคิดหลัก</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>ความแปรปรวนตัวอย่าง (s²)</strong>
+          <p>คำนวณจาก \(s^2 = \dfrac{\sum (x_i - \bar{x})^2}{n-1}\). ใช้เป็นตัวประมาณของ σ²</p>
+          <p>ต้องการข้อมูลจากประชากรที่มีการแจกแจงปกติ</p>
+        </article>
+        <article class="definition">
+          <strong>สถิติไคสแควร์</strong>
+          <p>\( \chi^2 = \dfrac{(n-1)s^2}{\sigma^2} \) มีการแจกแจงไคสแควร์ที่ df = n-1 เมื่อข้อมูลมาจากประชากรปกติ</p>
+          <p>ใช้ค่าตัด \(\chi^2_{\alpha/2, n-1}\) และ \(\chi^2_{1-\alpha/2, n-1}\)</p>
+        </article>
+      </div>
+      <div class="highlight">
+        <strong>สำคัญ</strong> ช่วงความเชื่อมั่นสำหรับความแปรปรวนจะไม่สมมาตร และไวต่อ outlier มากกว่าช่วงสำหรับค่าเฉลี่ย
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>2. สูตร</h2>
+      <p>สำหรับความแปรปรวน:</p>
+      <p>\[ \frac{(n-1)s^2}{\chi^2_{1-\alpha/2}} \le \sigma^2 \le \frac{(n-1)s^2}{\chi^2_{\alpha/2}} \]</p>
+      <p>สำหรับส่วนเบี่ยงเบนมาตรฐาน: นำรากที่สองของขอบเขตทั้งสอง</p>
+    </section>
+
+    <section class="card">
+      <h2>3. เครื่องคำนวณช่วงความเชื่อมั่นสำหรับ σ²/σ</h2>
+      <p>กรอกสถิติจากตัวอย่างเพื่อสร้างช่วง พร้อมดูโค้งไคสแควร์ที่สัมพันธ์กับข้อมูล.</p>
+      <div class="calculator">
+        <label>ส่วนเบี่ยงเบนมาตรฐานตัวอย่าง (s)
+          <input type="number" id="sd" value="6.8" step="0.01" min="0" />
+        </label>
+        <label>ขนาดตัวอย่าง (n)
+          <input type="number" id="n" value="18" min="2" />
+        </label>
+        <label>ระดับความเชื่อมั่น (%)
+          <input type="range" id="conf" min="80" max="99" value="95" />
+        </label>
+        <div class="note">ระดับความเชื่อมั่นปัจจุบัน: <span id="conf-text">95%</span></div>
+        <button id="calc">คำนวณช่วง</button>
+      </div>
+      <div class="result-card" id="summary" style="display:none"></div>
+      <canvas id="chi-chart" height="220"></canvas>
+    </section>
+
+    <section class="card">
+      <h2>4. ตัวอย่างและการตีความ</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>สถานการณ์</th>
+            <th>ข้อมูลตัวอย่าง</th>
+            <th>ช่วง 95%</th>
+            <th>สรุป</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>ความสม่ำเสมอของกระบวนการผลิต</td>
+            <td>s=4.2, n=12</td>
+            <td>σ² ∈ [8.6, 42.5]</td>
+            <td>ส่วนเบี่ยงเบนมาตรฐานจริงอยู่ระหว่าง 2.9–6.5 หน่วย</td>
+          </tr>
+          <tr>
+            <td>ความผันผวนเวลารอคิว</td>
+            <td>s=6.8, n=18</td>
+            <td>σ ∈ [5.4, 9.4]</td>
+            <td>ช่วยประเมินความไม่แน่นอน เพื่อวางแผนความจุบริการ</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="card">
+      <h2>5. Checklist</h2>
+      <ul>
+        <li>✅ ข้อมูลมาจากประชากรที่ใกล้เคียงปกติ</li>
+        <li>✅ ไม่มี outlier รุนแรง</li>
+        <li>✅ ใช้ s² จากการคำนวณแบบ n-1 (sample variance)</li>
+        <li>✅ ระบุ df = n-1 เสมอ</li>
+        <li>✅ ตีความช่วงด้วยค่าทั้ง σ² และ σ</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.5/dist/jstat.min.js"></script>
+  <script>
+    const sdInput = document.getElementById('sd');
+    const nInput = document.getElementById('n');
+    const confInput = document.getElementById('conf');
+    const confText = document.getElementById('conf-text');
+    const calcBtn = document.getElementById('calc');
+    const summary = document.getElementById('summary');
+    const ctx = document.getElementById('chi-chart');
+    let chart;
+
+    function updateChart(df, lower, upper) {
+      const points = 200;
+      const maxX = df + 4 * Math.sqrt(2 * df);
+      const labels = [];
+      const base = [];
+      const highlight = [];
+      for (let i = 0; i <= points; i += 1) {
+        const x = (maxX * i) / points;
+        const density = jStat.chisquare.pdf(x, df);
+        labels.push(x.toFixed(2));
+        base.push(density);
+        highlight.push(x >= lower && x <= upper ? density : null);
+      }
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: `Chi-square(df=${df})`,
+              data: base,
+              borderColor: 'rgba(106,27,154,0.45)',
+              borderWidth: 2,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: false
+            },
+            {
+              label: 'พื้นที่ช่วงที่เกี่ยวข้อง',
+              data: highlight,
+              borderColor: 'rgba(186,104,200,0.95)',
+              backgroundColor: 'rgba(186,104,200,0.35)',
+              borderWidth: 2.4,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: true
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { labels: { color: '#4a148c' } } },
+          scales: {
+            x: { title: { display: true, text: 'ค่า χ²', color: '#4a148c' }, ticks: { color: '#4a148c' } },
+            y: { title: { display: true, text: 'ความหนาแน่น', color: '#4a148c' }, ticks: { color: '#4a148c' } }
+          }
+        }
+      });
+    }
+
+    function calculate() {
+      const s = Math.max(parseFloat(sdInput.value), 1e-6);
+      const n = Math.max(parseInt(nInput.value, 10), 2);
+      nInput.value = n;
+      const df = n - 1;
+      const confidence = parseInt(confInput.value, 10) / 100;
+      confText.textContent = `${(confidence * 100).toFixed(0)}%`;
+      const alpha = 1 - confidence;
+      const chiLower = jStat.chisquare.inv(1 - alpha / 2, df);
+      const chiUpper = jStat.chisquare.inv(alpha / 2, df);
+      const lowerVar = (df * s * s) / chiLower;
+      const upperVar = (df * s * s) / chiUpper;
+      const lowerSd = Math.sqrt(lowerVar);
+      const upperSd = Math.sqrt(upperVar);
+
+      summary.style.display = 'grid';
+      summary.innerHTML = `
+        <strong>ช่วงความเชื่อมั่น</strong>
+        <span>σ² ∈ [${lowerVar.toFixed(3)}, ${upperVar.toFixed(3)}]</span>
+        <span>σ ∈ [${lowerSd.toFixed(3)}, ${upperSd.toFixed(3)}]</span>
+        <span>df = ${df}, χ²_{\alpha/2} = ${chiUpper.toFixed(3)}, χ²_{1-\alpha/2} = ${chiLower.toFixed(3)}</span>
+        <span class="note">ระบุว่าช่วงไม่สมมาตร และอ่อนไหวต่อค่าผิดปกติ</span>
+      `;
+
+      updateChart(df, chiUpper, chiLower);
+    }
+
+    confInput.addEventListener('input', () => { confText.textContent = `${confInput.value}%`; });
+    [sdInput, nInput].forEach(el => el.addEventListener('input', calculate));
+    confInput.addEventListener('change', calculate);
+    calcBtn.addEventListener('click', calculate);
+
+    calculate();
+  </script>
+</body>
+</html>

--- a/prob & Stats/content/23-ht-intro.html
+++ b/prob & Stats/content/23-ht-intro.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8" />
+  <title>บทที่ 23: บทนำการทดสอบสมมติฐาน</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      --accent: #1565c0;
+      --accent-light: #64b5f6;
+      --accent-dark: #0d47a1;
+      --card-bg: rgba(227, 242, 253, 0.94);
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+      min-height: 100vh;
+      background: radial-gradient(circle at 15% 18%, rgba(100,181,246,0.28), transparent 60%),
+                  radial-gradient(circle at 80% 20%, rgba(21,101,192,0.2), transparent 60%),
+                  linear-gradient(180deg, rgba(225,245,254,0.92), rgba(232,245,255,0.9));
+    }
+    main.container { max-width: 1120px; margin: 0 auto; padding: clamp(2rem, 5vw, 3.5rem); display: grid; gap: 2.2rem; }
+    header.hero { background: linear-gradient(135deg, var(--accent), var(--accent-light)); color: #fff; padding: clamp(2.6rem, 6vw, 4rem); border-radius: 32px; position: relative; overflow: hidden; box-shadow: 0 32px 54px rgba(13,71,161,0.26); }
+    header.hero::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 78% 18%, rgba(255,255,255,0.45), transparent 55%), radial-gradient(circle at 20% 78%, rgba(255,255,255,0.24), transparent 70%); }
+    header.hero h1 { font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem); margin-bottom: 0.75rem; }
+    header.hero p { font-size: 1.12rem; max-width: 720px; line-height: 1.7; }
+    section.card { background: var(--card-bg); border-radius: 26px; padding: clamp(1.8rem, 4vw, 2.6rem); box-shadow: 0 20px 36px rgba(21,101,192,0.16); backdrop-filter: blur(6px); display: grid; gap: 1.1rem; }
+    section.card h2 { color: var(--accent); font-size: 1.9rem; display: flex; align-items: center; gap: 0.75rem; margin: 0; }
+    .badge { background: rgba(21,101,192,0.12); color: var(--accent-dark); padding: 0.2rem 0.85rem; border-radius: 999px; font-size: 0.9rem; font-weight: 600; }
+    .grid { display: grid; gap: 1.2rem; }
+    @media (min-width: 960px) { .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    article.definition { padding: 1.35rem 1.6rem; border-radius: 20px; background: rgba(187,222,251,0.85); border: 1px solid rgba(21,101,192,0.18); display: grid; gap: 0.6rem; }
+    article.definition strong { color: var(--accent-dark); font-size: 1.05rem; }
+    .highlight { border-left: 6px solid var(--accent); padding: 1rem 1.25rem; background: rgba(21,101,192,0.1); border-radius: 18px; line-height: 1.7; }
+    .steps { display: grid; gap: 0.9rem; }
+    .steps article { background: rgba(255,255,255,0.95); border-radius: 18px; padding: 1rem 1.2rem; border: 1px solid rgba(21,101,192,0.12); display: grid; gap: 0.3rem; }
+    .steps article strong { color: var(--accent-dark); }
+    .simulator { display: grid; gap: 1rem; margin-top: 0.8rem; }
+    .simulator label { font-weight: 600; color: var(--accent-dark); display: grid; gap: 0.4rem; }
+    .simulator input { padding: 0.75rem 1rem; border-radius: 14px; border: 1px solid rgba(21,101,192,0.28); font-size: 1rem; background: rgba(255,255,255,0.95); }
+    .simulator button { background: linear-gradient(135deg, var(--accent-dark), var(--accent)); color: #fff; border: 0; border-radius: 14px; padding: 0.85rem 1.2rem; font-size: 1rem; font-weight: 600; cursor: pointer; transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .simulator button:hover { transform: translateY(-2px); box-shadow: 0 16px 30px rgba(13,71,161,0.22); }
+    .result-card { background: rgba(255,255,255,0.95); border-radius: 18px; padding: 1.2rem 1.4rem; border: 1px solid rgba(21,101,192,0.18); display: grid; gap: 0.6rem; }
+    canvas { background: rgba(255,255,255,0.88); border-radius: 18px; padding: 1rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.6rem 0.75rem; text-align: left; }
+    th { background: rgba(187,222,251,0.5); color: var(--accent-dark); }
+    tr:nth-child(even) { background: rgba(227,242,253,0.6); }
+  </style>
+</head>
+<body class="page">
+  <main class="container">
+    <header class="hero">
+      <span class="badge">Hypothesis Testing</span>
+      <h1>บทที่ 23: บทนำสู่การทดสอบสมมติฐาน</h1>
+      <p>ทำความเข้าใจปรัชญาและขั้นตอนของการทดสอบสมมติฐาน ตั้งแต่งานกำหนดสมมติฐานศูนย์และสมมติฐานทางเลือก ไปจนถึงการตัดสินใจด้วยสถิติทดสอบ.</p>
+    </header>
+
+    <section class="card">
+      <h2>1. คำศัพท์หลัก</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>สมมติฐานศูนย์ (H₀)</strong>
+          <p>คำกล่าวที่ถือเป็นค่าเริ่มต้น “ยังไม่มีการเปลี่ยนแปลง” มักใช้เครื่องหมาย = เช่น \(\mu = \mu_0\)</p>
+        </article>
+        <article class="definition">
+          <strong>สมมติฐานทางเลือก (H₁)</strong>
+          <p>สิ่งที่เราต้องการพิสูจน์ เช่น \(\mu > \mu_0\), \(p \ne p_0\)</p>
+        </article>
+      </div>
+      <div class="highlight">
+        <strong>ตรรกะการทดสอบ</strong> ถ้าข้อมูลขัดแย้งกับ H₀ มากพอ (สถิติทดสอบ “สุดโต่ง”) → ปฏิเสธ H₀ หากไม่ → ยังไม่ปฏิเสธ H₀
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>2. ขั้นตอนมาตรฐาน</h2>
+      <div class="steps">
+        <article>
+          <strong>1) กำหนด H₀ และ H₁</strong>
+          <span>ระบุรูปแบบ one-tail / two-tail ให้ชัดเจน</span>
+        </article>
+        <article>
+          <strong>2) เลือกระดับนัยสำคัญ (α)</strong>
+          <span>มักใช้ 0.05 หรือ 0.01 ขึ้นอยู่กับความเสี่ยงของ Type I error</span>
+        </article>
+        <article>
+          <strong>3) คำนวณสถิติทดสอบ</strong>
+          <span>เลือกสูตรที่เหมาะกับข้อมูล (z, t, χ², F)</span>
+        </article>
+        <article>
+          <strong>4) หาขอบเขตวิกฤติหรือ p-value</strong>
+          <span>เปรียบเทียบกับข้อมูล</span>
+        </article>
+        <article>
+          <strong>5) ตัดสินใจและตีความ</strong>
+          <span>ระบุผลลัพธ์ในบริบทเชิงธุรกิจ/วิทยาศาสตร์</span>
+        </article>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>3. ความผิดพลาดประเภท I และ II</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>Type I Error (False Positive)</strong>
+          <p>ปฏิเสธ H₀ ทั้งที่จริงๆ แล้ว H₀ ถูกต้อง ความน่าจะเป็นเท่ากับ α</p>
+        </article>
+        <article class="definition">
+          <strong>Type II Error (False Negative)</strong>
+          <p>ไม่ปฏิเสธ H₀ ทั้งที่จริง H₁ เป็นจริง ความน่าจะเป็นคือ β ซึ่งขึ้นกับขนาดตัวอย่างและ effect size</p>
+        </article>
+      </div>
+      <div class="highlight">
+        <strong>พลังการทดสอบ (Power)</strong> = 1 − β = โอกาสที่จะตรวจจับความแตกต่างเมื่อมีอยู่จริง
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>4. จำลองพื้นที่การตัดสินใจ</h2>
+      <p>ลองปรับระดับนัยสำคัญ (α) และขนาดเอฟเฟกต์เพื่อดูการทับซ้อนของการแจกแจงภายใต้ H₀ และ H₁</p>
+      <div class="simulator">
+        <label>ระดับนัยสำคัญ (α)
+          <input type="range" id="alpha" min="1" max="20" value="5" />
+        </label>
+        <div class="note">α = <span id="alpha-text">0.05</span></div>
+        <label>Effect size (หน่วยส่วนเบี่ยงเบนมาตรฐาน)
+          <input type="range" id="effect" min="10" max="80" value="30" />
+        </label>
+        <div class="note">Effect size = <span id="effect-text">0.30σ</span></div>
+        <button id="simulate">อัปเดตกราฟ</button>
+      </div>
+      <div class="result-card" id="sim-summary" style="display:none"></div>
+      <canvas id="ht-chart" height="220"></canvas>
+    </section>
+
+    <section class="card">
+      <h2>5. เปรียบเทียบการรายงานผล</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>องค์ประกอบ</th>
+            <th>รูปแบบรายงานที่ดี</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>สถิติทดสอบ</td>
+            <td>“t(28) = 2.31, p = 0.028”</td>
+          </tr>
+          <tr>
+            <td>ข้อสรุป</td>
+            <td>“มีหลักฐานว่าค่าเฉลี่ยหลังการอบรมสูงขึ้น”</td>
+          </tr>
+          <tr>
+            <td>ขนาดเอฟเฟกต์</td>
+            <td>รายงานเช่น Cohen’s d หรือผลต่างค่าเฉลี่ยพร้อมช่วงความเชื่อมั่น</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="card">
+      <h2>6. Checklist ก่อนตัดสินใจ</h2>
+      <ul>
+        <li>✅ ระบุ H₀/H₁ ชัดเจน</li>
+        <li>✅ เลือกระดับนัยสำคัญที่เหมาะสม</li>
+        <li>✅ ตรวจสอบเงื่อนไขการใช้สถิติ (เช่น ความเป็นปกติ)</li>
+        <li>✅ รายงานทั้ง p-value และขนาดเอฟเฟกต์</li>
+        <li>✅ สื่อสารผลในบริบทของปัญหาจริง</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.5/dist/jstat.min.js"></script>
+  <script>
+    const alphaInput = document.getElementById('alpha');
+    const alphaText = document.getElementById('alpha-text');
+    const effectInput = document.getElementById('effect');
+    const effectText = document.getElementById('effect-text');
+    const simulateBtn = document.getElementById('simulate');
+    const simSummary = document.getElementById('sim-summary');
+    const ctx = document.getElementById('ht-chart');
+    let chart;
+
+    function updateChart() {
+      const alpha = parseInt(alphaInput.value, 10) / 100;
+      const effect = parseInt(effectInput.value, 10) / 100;
+      alphaText.textContent = alpha.toFixed(2);
+      effectText.textContent = `${effect.toFixed(2)}σ`;
+      const zCritical = jStat.normal.inv(1 - alpha, 0, 1);
+      const beta = jStat.normal.cdf(zCritical - effect, 0, 1);
+      const power = 1 - beta;
+
+      const minX = -4;
+      const maxX = 4 + effect;
+      const points = 250;
+      const labels = [];
+      const h0Data = [];
+      const h1Data = [];
+      const rejectH0 = [];
+      const acceptH0 = [];
+      const rejectRegion = zCritical;
+
+      for (let i = 0; i <= points; i += 1) {
+        const x = minX + ((maxX - minX) * i) / points;
+        const h0 = jStat.normal.pdf(x, 0, 1);
+        const h1 = jStat.normal.pdf(x, effect, 1);
+        labels.push(x.toFixed(2));
+        h0Data.push(h0);
+        h1Data.push(h1);
+        rejectH0.push(x >= rejectRegion ? h0 : null);
+        acceptH0.push(x < rejectRegion ? h1 : null);
+      }
+
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'H₀ distribution',
+              data: h0Data,
+              borderColor: 'rgba(21,101,192,0.5)',
+              borderWidth: 2,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: false
+            },
+            {
+              label: 'H₁ distribution',
+              data: h1Data,
+              borderColor: 'rgba(255,193,7,0.75)',
+              borderWidth: 2,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: false
+            },
+            {
+              label: 'Type I error (α)',
+              data: rejectH0,
+              borderColor: 'rgba(229,57,53,0.9)',
+              backgroundColor: 'rgba(229,57,53,0.3)',
+              borderWidth: 0,
+              pointRadius: 0,
+              fill: true
+            },
+            {
+              label: 'Type II error (β)',
+              data: acceptH0,
+              borderColor: 'rgba(67,160,71,0.9)',
+              backgroundColor: 'rgba(67,160,71,0.3)',
+              borderWidth: 0,
+              pointRadius: 0,
+              fill: true
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { labels: { color: '#0d47a1' } } },
+          scales: {
+            x: { title: { display: true, text: 'สถิติทดสอบ (z)', color: '#0d47a1' }, ticks: { color: '#0d47a1' } },
+            y: { title: { display: true, text: 'ความหนาแน่น', color: '#0d47a1' }, ticks: { color: '#0d47a1' } }
+          },
+          annotation: false
+        }
+      });
+
+      simSummary.style.display = 'grid';
+      simSummary.innerHTML = `
+        <strong>สรุปการจำลอง</strong>
+        <span>α = ${alpha.toFixed(2)} → พื้นที่สีแดง</span>
+        <span>β ≈ ${beta.toFixed(3)} → พื้นที่สีเขียว</span>
+        <span>Power = ${(power * 100).toFixed(1)}%</span>
+        <span class="note">เพิ่มขนาดตัวอย่าง → ลด β (เพิ่ม power)</span>
+      `;
+    }
+
+    alphaInput.addEventListener('input', updateChart);
+    effectInput.addEventListener('input', updateChart);
+    simulateBtn.addEventListener('click', updateChart);
+
+    updateChart();
+  </script>
+</body>
+</html>

--- a/prob & Stats/content/24-ht-critical-pvalue.html
+++ b/prob & Stats/content/24-ht-critical-pvalue.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8" />
+  <title>บทที่ 24: Critical Value vs p-value</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      --accent: #00897b;
+      --accent-light: #4db6ac;
+      --accent-dark: #00695c;
+      --card-bg: rgba(224, 242, 241, 0.94);
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+      min-height: 100vh;
+      background: radial-gradient(circle at 15% 18%, rgba(77,182,172,0.26), transparent 60%),
+                  radial-gradient(circle at 80% 20%, rgba(0,137,123,0.2), transparent 60%),
+                  linear-gradient(180deg, rgba(224,242,241,0.92), rgba(232,245,243,0.9));
+    }
+    main.container { max-width: 1100px; margin: 0 auto; padding: clamp(2rem, 5vw, 3.5rem); display: grid; gap: 2.2rem; }
+    header.hero { background: linear-gradient(135deg, var(--accent), var(--accent-light)); color: #fff; padding: clamp(2.6rem, 6vw, 4rem); border-radius: 32px; position: relative; overflow: hidden; box-shadow: 0 32px 54px rgba(0,105,92,0.22); }
+    header.hero::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 80% 18%, rgba(255,255,255,0.4), transparent 55%), radial-gradient(circle at 20% 75%, rgba(255,255,255,0.24), transparent 70%); }
+    header.hero h1 { font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem); margin-bottom: 0.75rem; }
+    header.hero p { font-size: 1.12rem; max-width: 720px; line-height: 1.7; }
+    section.card { background: var(--card-bg); border-radius: 26px; padding: clamp(1.8rem, 4vw, 2.6rem); box-shadow: 0 20px 36px rgba(0,77,64,0.14); backdrop-filter: blur(6px); display: grid; gap: 1.1rem; }
+    section.card h2 { color: var(--accent-dark); font-size: 1.9rem; display: flex; align-items: center; gap: 0.75rem; margin: 0; }
+    .badge { background: rgba(0,105,92,0.15); color: #004d40; padding: 0.2rem 0.85rem; border-radius: 999px; font-size: 0.9rem; font-weight: 600; }
+    .grid { display: grid; gap: 1.2rem; }
+    @media (min-width: 960px) { .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    article.definition { padding: 1.35rem 1.6rem; border-radius: 20px; background: rgba(200,230,201,0.85); border: 1px solid rgba(0,105,92,0.18); display: grid; gap: 0.6rem; }
+    article.definition strong { color: var(--accent-dark); font-size: 1.05rem; }
+    .highlight { border-left: 6px solid var(--accent-dark); padding: 1rem 1.25rem; background: rgba(0,121,107,0.1); border-radius: 18px; line-height: 1.7; }
+    .simulator { display: grid; gap: 1rem; margin-top: 0.8rem; }
+    .simulator label { font-weight: 600; color: var(--accent-dark); display: grid; gap: 0.4rem; }
+    .simulator input, .simulator select { padding: 0.75rem 1rem; border-radius: 14px; border: 1px solid rgba(0,121,107,0.28); font-size: 1rem; background: rgba(255,255,255,0.95); }
+    .simulator button { background: linear-gradient(135deg, var(--accent-dark), var(--accent)); color: #fff; border: 0; border-radius: 14px; padding: 0.85rem 1.2rem; font-size: 1rem; font-weight: 600; cursor: pointer; transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .simulator button:hover { transform: translateY(-2px); box-shadow: 0 16px 30px rgba(0,105,92,0.2); }
+    .result-card { background: rgba(255,255,255,0.95); border-radius: 18px; padding: 1.2rem 1.4rem; border: 1px solid rgba(0,121,107,0.2); display: grid; gap: 0.6rem; }
+    canvas { background: rgba(255,255,255,0.88); border-radius: 18px; padding: 1rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.6rem 0.75rem; text-align: left; }
+    th { background: rgba(200,230,201,0.6); color: #004d40; }
+    tr:nth-child(even) { background: rgba(224,242,241,0.6); }
+  </style>
+</head>
+<body class="page">
+  <main class="container">
+    <header class="hero">
+      <span class="badge">Decision Approaches</span>
+      <h1>บทที่ 24: Critical Value vs p-value</h1>
+      <p>สองวิธีในการตัดสินใจจากการทดสอบสมมติฐานที่ให้ผลลัพธ์เหมือนกัน เรียนรู้ข้อดีข้อด้อยและวิธีแปลงไปมาระหว่างกัน.</p>
+    </header>
+
+    <section class="card">
+      <h2>1. นิยามแบบสั้น</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>Critical Value Method</strong>
+          <p>กำหนดขอบเขตวิกฤติล่วงหน้า ขึ้นกับ α และรูปแบบ tail จากนั้นเปรียบเทียบสถิติทดสอบกับค่าเกณฑ์</p>
+        </article>
+        <article class="definition">
+          <strong>p-value Method</strong>
+          <p>คำนวณความน่าจะเป็นที่สถิติทดสอบจะ “สุดโต่งเท่าหรือมากกว่า” ที่สังเกตได้ แล้วเปรียบเทียบกับ α</p>
+        </article>
+      </div>
+      <div class="highlight">
+        <strong>ผลลัพธ์</strong> ทั้งสองวิธีให้ข้อสรุปเหมือนกัน หากใช้ α เดียวกันและสถิติทดสอบเดียวกัน
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>2. ข้อดี-ข้อควรระวัง</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>Critical Value</strong>
+          <ul>
+            <li>ง่ายต่อการสื่อสารภาพรวม</li>
+            <li>ใช้ได้ดีสำหรับการคำนวณด้วยมือ/ตาราง</li>
+            <li>ไม่แสดงระดับหลักฐานละเอียดเท่า p-value</li>
+          </ul>
+        </article>
+        <article class="definition">
+          <strong>p-value</strong>
+          <ul>
+            <li>ให้ระดับหลักฐานต่อ H₀ โดยตรง</li>
+            <li>เหมาะกับงานวิจัยที่ต้องการรายงานละเอียด</li>
+            <li>ต้องตีความร่วมกับขนาดเอฟเฟกต์</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>3. เครื่องจำลองความสัมพันธ์</h2>
+      <p>เลือกระดับนัยสำคัญ รูปแบบการทดสอบ และค่าของสถิติทดสอบ (z) เพื่อดูว่าการตัดสินใจแบบ critical value และ p-value ให้ผลตรงกันอย่างไร.</p>
+      <div class="simulator">
+        <label>ระดับนัยสำคัญ (α)
+          <input type="range" id="alpha" min="1" max="15" value="5" />
+        </label>
+        <div class="note">α = <span id="alpha-text">0.05</span></div>
+        <label>รูปแบบการทดสอบ
+          <select id="tail">
+            <option value="two">สองด้าน (two-tailed)</option>
+            <option value="left">ด้านซ้าย</option>
+            <option value="right">ด้านขวา</option>
+          </select>
+        </label>
+        <label>ค่าที่สังเกต (สถิติ z)
+          <input type="range" id="zstat" min="-40" max="40" value="180" />
+        </label>
+        <div class="note">z = <span id="z-text">1.80</span></div>
+        <button id="simulate">อัปเดต</button>
+      </div>
+      <div class="result-card" id="summary" style="display:none"></div>
+      <canvas id="compare-chart" height="220"></canvas>
+    </section>
+
+    <section class="card">
+      <h2>4. ตัวอย่างรายงานผล</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>สถานการณ์</th>
+            <th>Critical Value</th>
+            <th>p-value</th>
+            <th>สรุป</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>ทดสอบ \(H_0: \mu = 70\) vs \(H_1: \mu > 70\)</td>
+            <td>z = 2.05 > z₀.₀₅ = 1.645 → ปฏิเสธ H₀</td>
+            <td>p = 0.020 < 0.05 → ปฏิเสธ H₀</td>
+            <td>มีหลักฐานว่าค่าเฉลี่ยมากกว่า 70</td>
+          </tr>
+          <tr>
+            <td>ทดสอบสองด้าน</td>
+            <td>|t| = 1.90 < t₀.025,28 = 2.048 → ไม่ปฏิเสธ H₀</td>
+            <td>p = 0.068 > 0.05 → ไม่ปฏิเสธ H₀</td>
+            <td>ข้อมูลไม่เพียงพอที่จะยืนยันความแตกต่าง</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="card">
+      <h2>5. Checklist</h2>
+      <ul>
+        <li>✅ ระบุ α และรูปแบบ tail ก่อนดูข้อมูล</li>
+        <li>✅ แสดงทั้งค่า critical และ p-value หากเป็นไปได้</li>
+        <li>✅ ตีความ p-value ว่าเป็นหลักฐานต่อ H₀ ไม่ใช่ความน่าจะเป็นของสมมติฐาน</li>
+        <li>✅ ใช้ขนาดเอฟเฟกต์หรือช่วงความเชื่อมั่นประกอบ</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.5/dist/jstat.min.js"></script>
+  <script>
+    const alphaInput = document.getElementById('alpha');
+    const alphaText = document.getElementById('alpha-text');
+    const tailSelect = document.getElementById('tail');
+    const zInput = document.getElementById('zstat');
+    const zText = document.getElementById('z-text');
+    const simulateBtn = document.getElementById('simulate');
+    const summaryCard = document.getElementById('summary');
+    const ctx = document.getElementById('compare-chart');
+    let chart;
+
+    function getCritical(alpha, tail) {
+      const prob = 1 - alpha;
+      if (tail === 'two') {
+        return jStat.normal.inv(1 - alpha / 2, 0, 1);
+      }
+      return jStat.normal.inv(prob, 0, 1);
+    }
+
+    function computePValue(z, tail) {
+      if (tail === 'two') {
+        return 2 * (1 - jStat.normal.cdf(Math.abs(z), 0, 1));
+      }
+      if (tail === 'right') {
+        return 1 - jStat.normal.cdf(z, 0, 1);
+      }
+      return jStat.normal.cdf(z, 0, 1);
+    }
+
+    function update() {
+      const alpha = parseInt(alphaInput.value, 10) / 100;
+      const z = parseInt(zInput.value, 10) / 10;
+      const tail = tailSelect.value;
+      alphaText.textContent = alpha.toFixed(2);
+      zText.textContent = z.toFixed(2);
+
+      const critical = getCritical(alpha, tail);
+      const pValue = computePValue(z, tail);
+      const reject = tail === 'left' ? z < -critical : (tail === 'right' ? z > critical : Math.abs(z) > critical);
+
+      summaryCard.style.display = 'grid';
+      summaryCard.innerHTML = `
+        <strong>ผลการคำนวณ</strong>
+        <span>Critical value = ${tail === 'two' ? '±' : ''}${critical.toFixed(3)}</span>
+        <span>p-value = ${pValue.toFixed(4)}</span>
+        <span>การตัดสินใจ: ${reject ? '<strong style="color:#c62828">ปฏิเสธ H₀</strong>' : '<strong style="color:#2e7d32">ยังไม่ปฏิเสธ H₀</strong>'}</span>
+        <span class="note">หมายเหตุ: ทั้งสองวิธีให้ผลเหมือนกันเสมอหากใช้ α เดียวกัน</span>
+      `;
+
+      const minX = -4;
+      const maxX = 4;
+      const labels = [];
+      const base = [];
+      const highlight = [];
+      const statHighlight = [];
+      const points = 240;
+      let lowerBound;
+      let upperBound;
+      if (tail === 'two') {
+        lowerBound = -critical;
+        upperBound = critical;
+      } else if (tail === 'right') {
+        lowerBound = critical;
+        upperBound = maxX;
+      } else {
+        lowerBound = minX;
+        upperBound = -critical;
+      }
+
+      for (let i = 0; i <= points; i += 1) {
+        const x = minX + ((maxX - minX) * i) / points;
+        const density = jStat.normal.pdf(x, 0, 1);
+        labels.push(x.toFixed(2));
+        base.push(density);
+        const inCritical = tail === 'two' ? (x <= -critical || x >= critical) : (x >= lowerBound && x <= upperBound);
+        highlight.push(inCritical ? density : null);
+        statHighlight.push(Math.abs(x - z) < 0.02 ? density : null);
+      }
+
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'การแจกแจงภายใต้ H₀',
+              data: base,
+              borderColor: 'rgba(0,105,92,0.4)',
+              borderWidth: 2,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: false
+            },
+            {
+              label: 'พื้นที่วิกฤติ',
+              data: highlight,
+              borderColor: 'rgba(38,166,154,0.9)',
+              backgroundColor: 'rgba(38,166,154,0.35)',
+              borderWidth: 0,
+              pointRadius: 0,
+              fill: true
+            },
+            {
+              label: 'ตำแหน่งสถิติทดสอบ',
+              data: statHighlight,
+              borderColor: 'rgba(255,112,67,0.9)',
+              backgroundColor: 'rgba(255,112,67,0.6)',
+              borderWidth: 2,
+              pointRadius: 0,
+              fill: true
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { labels: { color: '#004d40' } } },
+          scales: {
+            x: { title: { display: true, text: 'สถิติทดสอบ (z)', color: '#004d40' }, ticks: { color: '#004d40' } },
+            y: { title: { display: true, text: 'ความหนาแน่น', color: '#004d40' }, ticks: { color: '#004d40' } }
+          }
+        }
+      });
+    }
+
+    alphaInput.addEventListener('input', update);
+    tailSelect.addEventListener('change', update);
+    zInput.addEventListener('input', update);
+    simulateBtn.addEventListener('click', update);
+
+    update();
+  </script>
+</body>
+</html>

--- a/prob & Stats/content/25-ht-one-mean.html
+++ b/prob & Stats/content/25-ht-one-mean.html
@@ -1,0 +1,324 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8" />
+  <title>บทที่ 25: การทดสอบค่าเฉลี่ยประชากรเดียว</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      --accent: #d84315;
+      --accent-light: #ff8a65;
+      --accent-dark: #bf360c;
+      --card-bg: rgba(255, 243, 224, 0.94);
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+      min-height: 100vh;
+      background: radial-gradient(circle at 15% 18%, rgba(255,138,101,0.28), transparent 60%),
+                  radial-gradient(circle at 80% 18%, rgba(216,67,21,0.18), transparent 60%),
+                  linear-gradient(180deg, rgba(255,236,179,0.92), rgba(255,248,225,0.92));
+    }
+    main.container { max-width: 1120px; margin: 0 auto; padding: clamp(2rem, 5vw, 3.5rem); display: grid; gap: 2.2rem; }
+    header.hero { background: linear-gradient(135deg, var(--accent), var(--accent-light)); color: #fff; padding: clamp(2.6rem, 6vw, 4rem); border-radius: 32px; position: relative; overflow: hidden; box-shadow: 0 32px 54px rgba(191,54,12,0.25); }
+    header.hero::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 78% 18%, rgba(255,255,255,0.45), transparent 55%), radial-gradient(circle at 20% 75%, rgba(255,255,255,0.24), transparent 70%); }
+    header.hero h1 { font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem); margin-bottom: 0.75rem; }
+    header.hero p { font-size: 1.12rem; max-width: 720px; line-height: 1.7; }
+    section.card { background: var(--card-bg); border-radius: 26px; padding: clamp(1.8rem, 4vw, 2.6rem); box-shadow: 0 20px 36px rgba(191,54,12,0.12); backdrop-filter: blur(6px); display: grid; gap: 1.1rem; }
+    section.card h2 { color: var(--accent-dark); font-size: 1.9rem; display: flex; align-items: center; gap: 0.75rem; margin: 0; }
+    .badge { background: rgba(255,138,101,0.3); color: var(--accent-dark); padding: 0.2rem 0.85rem; border-radius: 999px; font-size: 0.9rem; font-weight: 600; }
+    .grid { display: grid; gap: 1.2rem; }
+    @media (min-width: 960px) { .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    article.definition { padding: 1.35rem 1.6rem; border-radius: 20px; background: rgba(255,224,178,0.85); border: 1px solid rgba(216,67,21,0.18); display: grid; gap: 0.6rem; }
+    article.definition strong { color: var(--accent-dark); font-size: 1.05rem; }
+    .highlight { border-left: 6px solid var(--accent-dark); padding: 1rem 1.25rem; background: rgba(251,140,0,0.12); border-radius: 18px; line-height: 1.7; }
+    .calculator { display: grid; gap: 1rem; margin-top: 0.8rem; }
+    .calculator label { font-weight: 600; color: var(--accent-dark); display: grid; gap: 0.4rem; }
+    .calculator input, .calculator select { padding: 0.75rem 1rem; border-radius: 14px; border: 1px solid rgba(216,67,21,0.28); font-size: 1rem; background: rgba(255,255,255,0.95); }
+    .calculator button { background: linear-gradient(135deg, var(--accent-dark), var(--accent)); color: #fff; border: 0; border-radius: 14px; padding: 0.85rem 1.2rem; font-size: 1rem; font-weight: 600; cursor: pointer; transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .calculator button:hover { transform: translateY(-2px); box-shadow: 0 16px 30px rgba(191,54,12,0.2); }
+    .result-card { background: rgba(255,255,255,0.95); border-radius: 18px; padding: 1.2rem 1.4rem; border: 1px solid rgba(216,67,21,0.18); display: grid; gap: 0.6rem; }
+    canvas { background: rgba(255,255,255,0.88); border-radius: 18px; padding: 1rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.6rem 0.75rem; text-align: left; }
+    th { background: rgba(255,204,128,0.6); color: var(--accent-dark); }
+    tr:nth-child(even) { background: rgba(255,236,179,0.6); }
+  </style>
+</head>
+<body class="page">
+  <main class="container">
+    <header class="hero">
+      <span class="badge">One-sample Mean Test</span>
+      <h1>บทที่ 25: การทดสอบค่าเฉลี่ยประชากรเดียว (μ)</h1>
+      <p>ใช้ข้อมูลตัวอย่างเพื่อตัดสินใจว่าสมมติฐานเกี่ยวกับค่าเฉลี่ยประชากรควรถูกปฏิเสธหรือไม่ โดยเลือกใช้ z-test หรือ t-test ตามความเหมาะสม.</p>
+    </header>
+
+    <section class="card">
+      <h2>1. เงื่อนไขเบื้องต้น</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>ทราบ σ หรือไม่?</strong>
+          <p>ถ้าทราบ σ และ n ใหญ่ → ใช้ z-test; หากไม่ทราบและ n เล็ก → ใช้ t-test (df = n-1)</p>
+        </article>
+        <article class="definition">
+          <strong>สมมติฐาน</strong>
+          <p>\(H_0: \mu = \mu_0\)</p>
+          <p>\(H_1\) สามารถเป็น >, < หรือ ≠ ตามปัญหา</p>
+        </article>
+      </div>
+      <div class="highlight">
+        <strong>ขั้นตอน</strong> (1) กำหนด H₀/H₁ (2) เลือก α (3) คำนวณสถิติทดสอบ (4) หา p-value หรือเปรียบเทียบกับ critical (5) ตัดสินใจ
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>2. สูตรสถิติทดสอบ</h2>
+      <p>z-test: \( z = \dfrac{\bar{x} - \mu_0}{\sigma / \sqrt{n}} \)</p>
+      <p>t-test: \( t = \dfrac{\bar{x} - \mu_0}{s / \sqrt{n}} \)</p>
+    </section>
+
+    <section class="card">
+      <h2>3. เครื่องมือทดสอบค่าเฉลี่ย</h2>
+      <p>กรอกข้อมูลและเลือกรูปแบบสมมติฐาน ระบบจะคำนวณสถิติทดสอบ p-value และแสดงพื้นที่ปฏิเสธบนกราฟ.</p>
+      <div class="calculator">
+        <label>เลือกประเภทการทดสอบ
+          <select id="test-type">
+            <option value="z">ทราบ σ (z-test)</option>
+            <option value="t">ไม่ทราบ σ (t-test)</option>
+          </select>
+        </label>
+        <label>ค่าเฉลี่ยตัวอย่าง (\(\bar{x}\))
+          <input type="number" id="sample-mean" value="74.8" step="0.01" />
+        </label>
+        <label>ค่าเฉลี่ยตาม H₀ (\(\mu_0\))
+          <input type="number" id="hyp-mean" value="72" step="0.01" />
+        </label>
+        <label id="spread-label">ส่วนเบี่ยงเบนมาตรฐาน <span id="spread-text">(σ หรือ s)</span>
+          <input type="number" id="spread" value="9.5" step="0.01" min="0" />
+        </label>
+        <label>ขนาดตัวอย่าง (n)
+          <input type="number" id="sample-size" value="25" min="2" />
+        </label>
+        <label>ระดับนัยสำคัญ (α)
+          <input type="range" id="alpha" min="1" max="15" value="5" />
+        </label>
+        <div class="note">α = <span id="alpha-text">0.05</span></div>
+        <label>รูปแบบสมมติฐานทางเลือก (H₁)
+          <select id="tail">
+            <option value="two">≠ (สองด้าน)</option>
+            <option value="right">> (ด้านขวา)</option>
+            <option value="left">< (ด้านซ้าย)</option>
+          </select>
+        </label>
+        <button id="calc">คำนวณผลการทดสอบ</button>
+      </div>
+      <div class="result-card" id="summary" style="display:none"></div>
+      <canvas id="test-chart" height="220"></canvas>
+    </section>
+
+    <section class="card">
+      <h2>4. ตัวอย่างการตีความ</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>สถานการณ์</th>
+            <th>ข้อมูล</th>
+            <th>ผล</th>
+            <th>ข้อสรุป</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>เวลาจัดส่งเฉลี่ย (z-test)</td>
+            <td>\(\bar{x}=46\), σ=5, n=40, H₀: μ=48</td>
+            <td>z=-2.53, p=0.011</td>
+            <td>ปฏิเสธ H₀ → ระยะเวลาจัดส่งลดลงอย่างมีนัยสำคัญ</td>
+          </tr>
+          <tr>
+            <td>คะแนนหลังอบรม (t-test)</td>
+            <td>\(\bar{x}=78\), s=10, n=15, H₀: μ=75</td>
+            <td>t=1.16, p=0.266</td>
+            <td>ยังไม่ปฏิเสธ H₀ → หลักฐานไม่พอว่าคะแนนเพิ่มขึ้น</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="card">
+      <h2>5. Checklist</h2>
+      <ul>
+        <li>✅ ตรวจสอบการสุ่มและความเป็นปกติ (โดยเฉพาะเมื่อใช้ t-test)</li>
+        <li>✅ เลือกระดับ α ก่อนเห็นข้อมูล</li>
+        <li>✅ รายงานทั้งสถิติทดสอบ p-value และขนาดเอฟเฟกต์</li>
+        <li>✅ ตีความผลในบริบท เช่น ผลกระทบต่อธุรกิจ</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.5/dist/jstat.min.js"></script>
+  <script>
+    const testType = document.getElementById('test-type');
+    const meanInput = document.getElementById('sample-mean');
+    const hypInput = document.getElementById('hyp-mean');
+    const spreadInput = document.getElementById('spread');
+    const spreadLabel = document.getElementById('spread-label');
+    const spreadText = document.getElementById('spread-text');
+    const sizeInput = document.getElementById('sample-size');
+    const alphaInput = document.getElementById('alpha');
+    const alphaText = document.getElementById('alpha-text');
+    const tailSelect = document.getElementById('tail');
+    const calcBtn = document.getElementById('calc');
+    const summary = document.getElementById('summary');
+    const ctx = document.getElementById('test-chart');
+    let chart;
+
+    function updateLabel() {
+      spreadText.textContent = testType.value === 'z'
+        ? '(σ ของประชากร)'
+        : '(s ของตัวอย่าง)';
+    }
+
+    function criticalValue(alpha, tail, df, type) {
+      if (type === 'z') {
+        return tail === 'two'
+          ? jStat.normal.inv(1 - alpha / 2, 0, 1)
+          : jStat.normal.inv(1 - alpha, 0, 1);
+      }
+      return tail === 'two'
+        ? jStat.studentt.inv(1 - alpha / 2, df)
+        : jStat.studentt.inv(1 - alpha, df);
+    }
+
+    function pValue(stat, tail, df, type) {
+      if (type === 'z') {
+        if (tail === 'two') return 2 * (1 - jStat.normal.cdf(Math.abs(stat), 0, 1));
+        if (tail === 'right') return 1 - jStat.normal.cdf(stat, 0, 1);
+        return jStat.normal.cdf(stat, 0, 1);
+      }
+      if (tail === 'two') return 2 * (1 - jStat.studentt.cdf(Math.abs(stat), df));
+      if (tail === 'right') return 1 - jStat.studentt.cdf(stat, df);
+      return jStat.studentt.cdf(stat, df);
+    }
+
+    function updateChart(stat, crit, tail, type, se, df) {
+      const minX = -4;
+      const maxX = 4;
+      const points = 240;
+      const labels = [];
+      const base = [];
+      const highlight = [];
+      const statLine = [];
+      let lowerBound;
+      let upperBound;
+      if (tail === 'two') {
+        lowerBound = -crit;
+        upperBound = crit;
+      } else if (tail === 'right') {
+        lowerBound = crit;
+        upperBound = maxX;
+      } else {
+        lowerBound = minX;
+        upperBound = -crit;
+      }
+
+      for (let i = 0; i <= points; i += 1) {
+        const x = minX + ((maxX - minX) * i) / points;
+        const density = type === 'z' ? jStat.normal.pdf(x, 0, 1) : jStat.studentt.pdf(x, df);
+        labels.push(x.toFixed(2));
+        base.push(density);
+        const inCritical = tail === 'two' ? (x <= -crit || x >= crit) : (x >= lowerBound && x <= upperBound);
+        highlight.push(inCritical ? density : null);
+        statLine.push(Math.abs(x - stat) < 0.02 ? density : null);
+      }
+
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: type === 'z' ? 'มาตรฐานปกติ' : `t(df=${sizeInput.value - 1})`,
+              data: base,
+              borderColor: 'rgba(191,54,12,0.4)',
+              borderWidth: 2,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: false
+            },
+            {
+              label: 'พื้นที่วิกฤติ',
+              data: highlight,
+              borderColor: 'rgba(255,112,67,0.9)',
+              backgroundColor: 'rgba(255,112,67,0.35)',
+              borderWidth: 0,
+              pointRadius: 0,
+              fill: true
+            },
+            {
+              label: 'สถิติทดสอบ',
+              data: statLine,
+              borderColor: 'rgba(255,193,7,0.9)',
+              backgroundColor: 'rgba(255,213,79,0.7)',
+              borderWidth: 2,
+              pointRadius: 0,
+              fill: true
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { labels: { color: '#bf360c' } } },
+          scales: {
+            x: { title: { display: true, text: `${type === 'z' ? 'z' : 't'}-statistic`, color: '#bf360c' }, ticks: { color: '#bf360c' } },
+            y: { title: { display: true, text: 'ความหนาแน่น', color: '#bf360c' }, ticks: { color: '#bf360c' } }
+          }
+        }
+      });
+    }
+
+    function calculate() {
+      const type = testType.value;
+      const mean = parseFloat(meanInput.value);
+      const mu0 = parseFloat(hypInput.value);
+      const spread = Math.max(parseFloat(spreadInput.value), 1e-6);
+      let n = Math.max(parseInt(sizeInput.value, 10), 2);
+      sizeInput.value = n;
+      const alpha = parseInt(alphaInput.value, 10) / 100;
+      alphaText.textContent = alpha.toFixed(2);
+      const tail = tailSelect.value;
+      const se = spread / Math.sqrt(n);
+      let stat;
+      if (type === 'z') {
+        stat = (mean - mu0) / se;
+      } else {
+        stat = (mean - mu0) / se;
+      }
+      const df = n - 1;
+      const crit = criticalValue(alpha, tail, df, type);
+      const p = pValue(stat, tail, df, type);
+      const reject = tail === 'two' ? Math.abs(stat) > crit : (tail === 'right' ? stat > crit : stat < (type === 'z' ? -crit : -crit));
+
+      summary.style.display = 'grid';
+      summary.innerHTML = `
+        <strong>ผลการทดสอบ</strong>
+        <span>${type.toUpperCase()}-stat = ${stat.toFixed(3)} | SE = ${se.toFixed(3)}</span>
+        <span>Critical value = ${tail === 'two' ? '±' : ''}${crit.toFixed(3)} | p-value = ${p.toFixed(4)}</span>
+        <span>การตัดสินใจ: ${reject ? '<strong style="color:#c62828">ปฏิเสธ H₀</strong>' : '<strong style="color:#2e7d32">ยังไม่ปฏิเสธ H₀</strong>'}</span>
+        <span class="note">ตรวจสอบว่าข้อสรุปอยู่ในบริบทที่เหมาะสม และรายงานช่วงความเชื่อมั่นประกอบเมื่อเป็นไปได้</span>
+      `;
+
+      updateChart(stat, crit, tail, type, se, df);
+    }
+
+    testType.addEventListener('change', () => {
+      updateLabel();
+      calculate();
+    });
+    [meanInput, hypInput, spreadInput, sizeInput, tailSelect].forEach(el => el.addEventListener('input', calculate));
+    alphaInput.addEventListener('input', calculate);
+    calcBtn.addEventListener('click', calculate);
+
+    updateLabel();
+    calculate();
+  </script>
+</body>
+</html>

--- a/prob & Stats/content/26-ht-one-proportion.html
+++ b/prob & Stats/content/26-ht-one-proportion.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8" />
+  <title>บทที่ 26: การทดสอบสัดส่วนประชากรเดียว</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      --accent: #5d4037;
+      --accent-light: #a1887f;
+      --accent-dark: #4e342e;
+      --card-bg: rgba(239, 235, 233, 0.94);
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+      min-height: 100vh;
+      background: radial-gradient(circle at 15% 18%, rgba(161,136,127,0.28), transparent 60%),
+                  radial-gradient(circle at 80% 18%, rgba(93,64,55,0.2), transparent 60%),
+                  linear-gradient(180deg, rgba(250,245,240,0.92), rgba(236,239,241,0.9));
+    }
+    main.container { max-width: 1100px; margin: 0 auto; padding: clamp(2rem, 5vw, 3.5rem); display: grid; gap: 2.2rem; }
+    header.hero { background: linear-gradient(135deg, var(--accent), var(--accent-light)); color: #fff; padding: clamp(2.6rem, 6vw, 4rem); border-radius: 32px; position: relative; overflow: hidden; box-shadow: 0 32px 54px rgba(78,52,46,0.24); }
+    header.hero::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 78% 18%, rgba(255,255,255,0.45), transparent 55%), radial-gradient(circle at 20% 75%, rgba(255,255,255,0.24), transparent 70%); }
+    header.hero h1 { font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem); margin-bottom: 0.75rem; }
+    header.hero p { font-size: 1.12rem; max-width: 720px; line-height: 1.7; }
+    section.card { background: var(--card-bg); border-radius: 26px; padding: clamp(1.8rem, 4vw, 2.6rem); box-shadow: 0 20px 36px rgba(78,52,46,0.12); backdrop-filter: blur(6px); display: grid; gap: 1.1rem; }
+    section.card h2 { color: var(--accent-dark); font-size: 1.9rem; display: flex; align-items: center; gap: 0.75rem; margin: 0; }
+    .badge { background: rgba(93,64,55,0.2); color: var(--accent-dark); padding: 0.2rem 0.85rem; border-radius: 999px; font-size: 0.9rem; font-weight: 600; }
+    .grid { display: grid; gap: 1.2rem; }
+    @media (min-width: 960px) { .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    article.definition { padding: 1.35rem 1.6rem; border-radius: 20px; background: rgba(215,204,200,0.85); border: 1px solid rgba(93,64,55,0.18); display: grid; gap: 0.6rem; }
+    article.definition strong { color: var(--accent-dark); font-size: 1.05rem; }
+    .highlight { border-left: 6px solid var(--accent-dark); padding: 1rem 1.25rem; background: rgba(141,110,99,0.15); border-radius: 18px; line-height: 1.7; }
+    .calculator { display: grid; gap: 1rem; margin-top: 0.8rem; }
+    .calculator label { font-weight: 600; color: var(--accent-dark); display: grid; gap: 0.4rem; }
+    .calculator input, .calculator select { padding: 0.75rem 1rem; border-radius: 14px; border: 1px solid rgba(93,64,55,0.28); font-size: 1rem; background: rgba(255,255,255,0.95); }
+    .calculator button { background: linear-gradient(135deg, var(--accent-dark), var(--accent)); color: #fff; border: 0; border-radius: 14px; padding: 0.85rem 1.2rem; font-size: 1rem; font-weight: 600; cursor: pointer; transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .calculator button:hover { transform: translateY(-2px); box-shadow: 0 16px 30px rgba(78,52,46,0.2); }
+    .result-card { background: rgba(255,255,255,0.95); border-radius: 18px; padding: 1.2rem 1.4rem; border: 1px solid rgba(141,110,99,0.2); display: grid; gap: 0.6rem; }
+    canvas { background: rgba(255,255,255,0.88); border-radius: 18px; padding: 1rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.6rem 0.75rem; text-align: left; }
+    th { background: rgba(215,204,200,0.6); color: var(--accent-dark); }
+    tr:nth-child(even) { background: rgba(239,235,233,0.6); }
+  </style>
+</head>
+<body class="page">
+  <main class="container">
+    <header class="hero">
+      <span class="badge">One-sample Proportion Test</span>
+      <h1>บทที่ 26: การทดสอบสัดส่วนประชากรเดียว (p)</h1>
+      <p>ตรวจสอบว่าสัดส่วนประชากรแตกต่างจากค่าที่คาดไว้หรือไม่ โดยอาศัยการแจกแจงปกติประมาณของสัดส่วนเมื่อขนาดตัวอย่างเพียงพอ.</p>
+    </header>
+
+    <section class="card">
+      <h2>1. เงื่อนไข</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>สมมติฐาน</strong>
+          <p>\(H_0: p = p_0\)</p>
+          <p>\(H_1\) เป็น >, < หรือ ≠</p>
+        </article>
+        <article class="definition">
+          <strong>เงื่อนไขการประมาณ</strong>
+          <ul>
+            <li>ตัวอย่างสุ่มเป็นอิสระ</li>
+            <li>\(n p_0 ≥ 10\) และ \(n(1-p_0) ≥ 10\)</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>2. สถิติทดสอบ</h2>
+      <p>\[ z = \frac{\hat{p} - p_0}{\sqrt{ \frac{p_0(1-p_0)}{n} }} \]</p>
+      <p class="highlight">หมายเหตุ: ใช้ p₀ ในการคำนวณส่วนเบี่ยงเบนมาตรฐาน ไม่ใช่ \(\hat{p}\)</p>
+    </section>
+
+    <section class="card">
+      <h2>3. เครื่องมือคำนวณ</h2>
+      <div class="calculator">
+        <label>จำนวนความสำเร็จ (x)
+          <input type="number" id="success" value="120" min="0" />
+        </label>
+        <label>ขนาดตัวอย่าง (n)
+          <input type="number" id="total" value="320" min="1" />
+        </label>
+        <label>สัดส่วนตาม H₀ (p₀)
+          <input type="number" id="p0" value="0.35" step="0.01" min="0" max="1" />
+        </label>
+        <label>ระดับนัยสำคัญ (α)
+          <input type="range" id="alpha" min="1" max="15" value="5" />
+        </label>
+        <div class="note">α = <span id="alpha-text">0.05</span></div>
+        <label>รูปแบบ H₁
+          <select id="tail">
+            <option value="two">≠ (สองด้าน)</option>
+            <option value="right">> (ด้านขวา)</option>
+            <option value="left">< (ด้านซ้าย)</option>
+          </select>
+        </label>
+        <button id="calc">คำนวณผล</button>
+      </div>
+      <div class="result-card" id="summary" style="display:none"></div>
+      <canvas id="prop-chart" height="220"></canvas>
+    </section>
+
+    <section class="card">
+      <h2>4. ตัวอย่างการตีความ</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>สถานการณ์</th>
+            <th>ข้อมูล</th>
+            <th>ผลการทดสอบ</th>
+            <th>สรุป</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>ตรวจสอบอัตราลูกค้าที่แนะนำเพื่อน</td>
+            <td>x=185, n=400, p₀=0.4</td>
+            <td>z=2.19, p=0.028</td>
+            <td>ปฏิเสธ H₀ → อัตราจริงสูงกว่า 40%</td>
+          </tr>
+          <tr>
+            <td>ตรวจสอบอัตราของเสียไม่เกิน 5%</td>
+            <td>x=18, n=500, p₀=0.05</td>
+            <td>z=-1.58, p=0.114</td>
+            <td>ยังไม่ปฏิเสธ H₀ → หลักฐานไม่พอว่าของเสียเกิน 5%</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="card">
+      <h2>5. Checklist</h2>
+      <ul>
+        <li>✅ ตรวจสอบเงื่อนไข np₀ และ n(1-p₀)</li>
+        <li>✅ ระบุรูปแบบ H₁ ชัดเจน</li>
+        <li>✅ รายงานทั้ง z, p-value และขนาดเอฟเฟกต์ (เช่น ความต่าง \(\hat{p} - p_0\))</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.5/dist/jstat.min.js"></script>
+  <script>
+    const successInput = document.getElementById('success');
+    const totalInput = document.getElementById('total');
+    const p0Input = document.getElementById('p0');
+    const alphaInput = document.getElementById('alpha');
+    const alphaText = document.getElementById('alpha-text');
+    const tailSelect = document.getElementById('tail');
+    const calcBtn = document.getElementById('calc');
+    const summary = document.getElementById('summary');
+    const ctx = document.getElementById('prop-chart');
+    let chart;
+
+    function criticalValue(alpha, tail) {
+      return tail === 'two'
+        ? jStat.normal.inv(1 - alpha / 2, 0, 1)
+        : jStat.normal.inv(1 - alpha, 0, 1);
+    }
+
+    function pValue(stat, tail) {
+      if (tail === 'two') return 2 * (1 - jStat.normal.cdf(Math.abs(stat), 0, 1));
+      if (tail === 'right') return 1 - jStat.normal.cdf(stat, 0, 1);
+      return jStat.normal.cdf(stat, 0, 1);
+    }
+
+    function updateChart(stat, crit, tail) {
+      const minX = -4;
+      const maxX = 4;
+      const points = 240;
+      const labels = [];
+      const base = [];
+      const highlight = [];
+      const statLine = [];
+      let lowerBound;
+      let upperBound;
+      if (tail === 'two') {
+        lowerBound = -crit;
+        upperBound = crit;
+      } else if (tail === 'right') {
+        lowerBound = crit;
+        upperBound = maxX;
+      } else {
+        lowerBound = minX;
+        upperBound = -crit;
+      }
+
+      for (let i = 0; i <= points; i += 1) {
+        const x = minX + ((maxX - minX) * i) / points;
+        const density = jStat.normal.pdf(x, 0, 1);
+        labels.push(x.toFixed(2));
+        base.push(density);
+        const inCritical = tail === 'two' ? (x <= -crit || x >= crit) : (x >= lowerBound && x <= upperBound);
+        highlight.push(inCritical ? density : null);
+        statLine.push(Math.abs(x - stat) < 0.02 ? density : null);
+      }
+
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'มาตรฐานปกติ',
+              data: base,
+              borderColor: 'rgba(93,64,55,0.4)',
+              borderWidth: 2,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: false
+            },
+            {
+              label: 'พื้นที่วิกฤติ',
+              data: highlight,
+              borderColor: 'rgba(141,110,99,0.9)',
+              backgroundColor: 'rgba(141,110,99,0.35)',
+              borderWidth: 0,
+              pointRadius: 0,
+              fill: true
+            },
+            {
+              label: 'สถิติทดสอบ',
+              data: statLine,
+              borderColor: 'rgba(255,112,67,0.9)',
+              backgroundColor: 'rgba(255,183,77,0.6)',
+              borderWidth: 2,
+              pointRadius: 0,
+              fill: true
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { labels: { color: '#4e342e' } } },
+          scales: {
+            x: { title: { display: true, text: 'z-statistic', color: '#4e342e' }, ticks: { color: '#4e342e' } },
+            y: { title: { display: true, text: 'ความหนาแน่น', color: '#4e342e' }, ticks: { color: '#4e342e' } }
+          }
+        }
+      });
+    }
+
+    function calculate() {
+      const x = Math.max(parseInt(successInput.value, 10), 0);
+      const n = Math.max(parseInt(totalInput.value, 10), 1);
+      successInput.value = x;
+      totalInput.value = n;
+      const p0 = Math.min(Math.max(parseFloat(p0Input.value), 0), 1);
+      p0Input.value = p0;
+      const alpha = parseInt(alphaInput.value, 10) / 100;
+      alphaText.textContent = alpha.toFixed(2);
+      const tail = tailSelect.value;
+      const phat = x / n;
+      const se = Math.sqrt((p0 * (1 - p0)) / n);
+      const stat = (phat - p0) / se;
+      const crit = criticalValue(alpha, tail);
+      const p = pValue(stat, tail);
+      const reject = tail === 'two' ? Math.abs(stat) > crit : (tail === 'right' ? stat > crit : stat < -crit);
+
+      summary.style.display = 'grid';
+      summary.innerHTML = `
+        <strong>ผลการทดสอบ</strong>
+        <span>\u005Chat{p} = ${(phat * 100).toFixed(2)}% (${x}/${n}), p₀ = ${(p0 * 100).toFixed(1)}%</span>
+        <span>z = ${stat.toFixed(3)} | Critical = ${tail === 'two' ? '±' : ''}${crit.toFixed(3)}</span>
+        <span>p-value = ${p.toFixed(4)}</span>
+        <span>การตัดสินใจ: ${reject ? '<strong style="color:#c62828">ปฏิเสธ H₀</strong>' : '<strong style="color:#2e7d32">ยังไม่ปฏิเสธ H₀</strong>'}</span>
+      `;
+
+      updateChart(stat, crit, tail);
+    }
+
+    [successInput, totalInput, p0Input, tailSelect].forEach(el => el.addEventListener('input', calculate));
+    alphaInput.addEventListener('input', calculate);
+    calcBtn.addEventListener('click', calculate);
+
+    calculate();
+  </script>
+</body>
+</html>

--- a/prob & Stats/content/27-ht-two-means.html
+++ b/prob & Stats/content/27-ht-two-means.html
@@ -1,0 +1,368 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8" />
+  <title>บทที่ 27: การทดสอบผลต่างค่าเฉลี่ยสองประชากร</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      --accent: #3949ab;
+      --accent-light: #7986cb;
+      --accent-dark: #283593;
+      --card-bg: rgba(232, 234, 246, 0.94);
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+      min-height: 100vh;
+      background: radial-gradient(circle at 15% 18%, rgba(121,134,203,0.26), transparent 60%),
+                  radial-gradient(circle at 80% 18%, rgba(57,73,171,0.2), transparent 60%),
+                  linear-gradient(180deg, rgba(227,242,253,0.92), rgba(232,234,246,0.9));
+    }
+    main.container { max-width: 1150px; margin: 0 auto; padding: clamp(2rem, 5vw, 3.5rem); display: grid; gap: 2.2rem; }
+    header.hero { background: linear-gradient(135deg, var(--accent), var(--accent-light)); color: #fff; padding: clamp(2.6rem, 6vw, 4rem); border-radius: 32px; position: relative; overflow: hidden; box-shadow: 0 32px 54px rgba(40,53,147,0.24); }
+    header.hero::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 78% 18%, rgba(255,255,255,0.4), transparent 55%), radial-gradient(circle at 20% 75%, rgba(255,255,255,0.24), transparent 70%); }
+    header.hero h1 { font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem); margin-bottom: 0.75rem; }
+    header.hero p { font-size: 1.12rem; max-width: 760px; line-height: 1.7; }
+    section.card { background: var(--card-bg); border-radius: 26px; padding: clamp(1.8rem, 4vw, 2.6rem); box-shadow: 0 20px 36px rgba(40,53,147,0.14); backdrop-filter: blur(6px); display: grid; gap: 1.1rem; }
+    section.card h2 { color: var(--accent-dark); font-size: 1.9rem; display: flex; align-items: center; gap: 0.75rem; margin: 0; }
+    .badge { background: rgba(57,73,171,0.16); color: #1a237e; padding: 0.2rem 0.85rem; border-radius: 999px; font-size: 0.9rem; font-weight: 600; }
+    .grid { display: grid; gap: 1.2rem; }
+    @media (min-width: 960px) { .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    article.definition { padding: 1.35rem 1.6rem; border-radius: 20px; background: rgba(197,202,233,0.85); border: 1px solid rgba(57,73,171,0.18); display: grid; gap: 0.6rem; }
+    article.definition strong { color: var(--accent-dark); font-size: 1.05rem; }
+    .highlight { border-left: 6px solid var(--accent); padding: 1rem 1.25rem; background: rgba(121,134,203,0.12); border-radius: 18px; line-height: 1.7; }
+    .calculator { display: grid; gap: 1rem; margin-top: 0.8rem; }
+    .calculator label { font-weight: 600; color: var(--accent-dark); display: grid; gap: 0.4rem; }
+    .calculator input, .calculator select { padding: 0.75rem 1rem; border-radius: 14px; border: 1px solid rgba(57,73,171,0.28); font-size: 1rem; background: rgba(255,255,255,0.95); }
+    .calculator button { background: linear-gradient(135deg, var(--accent-dark), var(--accent)); color: #fff; border: 0; border-radius: 14px; padding: 0.85rem 1.2rem; font-size: 1rem; font-weight: 600; cursor: pointer; transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .calculator button:hover { transform: translateY(-2px); box-shadow: 0 16px 30px rgba(40,53,147,0.22); }
+    .result-card { background: rgba(255,255,255,0.95); border-radius: 18px; padding: 1.2rem 1.4rem; border: 1px solid rgba(57,73,171,0.18); display: grid; gap: 0.6rem; }
+    canvas { background: rgba(255,255,255,0.88); border-radius: 18px; padding: 1rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.6rem 0.75rem; text-align: left; }
+    th { background: rgba(197,202,233,0.6); color: var(--accent-dark); }
+    tr:nth-child(even) { background: rgba(226,231,255,0.6); }
+    .flex { display: grid; gap: 1rem; }
+    @media (min-width: 900px) { .flex { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+  </style>
+</head>
+<body class="page">
+  <main class="container">
+    <header class="hero">
+      <span class="badge">Two-sample Mean Test</span>
+      <h1>บทที่ 27: การทดสอบผลต่างค่าเฉลี่ยสองประชากร</h1>
+      <p>เลือกใช้ t-test แบบ Welch, pooled หรือ paired เพื่อตรวจสอบว่าค่าเฉลี่ยของสองกลุ่มต่างกันหรือไม่ พร้อมเครื่องมือที่ปรับได้ตามสถานการณ์.</p>
+    </header>
+
+    <section class="card">
+      <h2>1. เลือกการตั้งค่าที่ถูกต้อง</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>สองกลุ่มอิสระ</strong>
+          <p>ใช้ Welch เมื่อไม่สมมติ σ² เท่ากัน และ pooled เมื่อเชื่อว่า σ₁² ≈ σ₂²</p>
+        </article>
+        <article class="definition">
+          <strong>ข้อมูลจับคู่</strong>
+          <p>คำนวณความต่างต่อคู่ (d) แล้วใช้ t-test แบบหนึ่งตัวอย่างกับ \(\bar{d}\)</p>
+        </article>
+      </div>
+      <div class="highlight">ปรับ tail (>, <, ≠) ตาม H₁ ที่ต้องการทดสอบ</div>
+    </section>
+
+    <section class="card">
+      <h2>2. เครื่องมือคำนวณ</h2>
+      <div class="calculator">
+        <label>ประเภทข้อมูล
+          <select id="mode">
+            <option value="welch">สองกลุ่มอิสระ (Welch)</option>
+            <option value="pooled">สองกลุ่มอิสระ (Pooled)</option>
+            <option value="paired">ข้อมูลจับคู่</option>
+          </select>
+        </label>
+        <div id="independent-fields" class="flex">
+          <div>
+            <label>\(\bar{x}_1\)
+              <input type="number" id="mean1" value="75.2" step="0.01" />
+            </label>
+            <label>s₁
+              <input type="number" id="sd1" value="9.1" step="0.01" min="0" />
+            </label>
+            <label>n₁
+              <input type="number" id="n1" value="30" min="2" />
+            </label>
+          </div>
+          <div>
+            <label>\(\bar{x}_2\)
+              <input type="number" id="mean2" value="69.4" step="0.01" />
+            </label>
+            <label>s₂
+              <input type="number" id="sd2" value="10.2" step="0.01" min="0" />
+            </label>
+            <label>n₂
+              <input type="number" id="n2" value="28" min="2" />
+            </label>
+          </div>
+        </div>
+        <div id="paired-fields" style="display:none">
+          <label>ค่าเฉลี่ยความต่าง (\(\bar{d}\))
+            <input type="number" id="mean-d" value="4.1" step="0.01" />
+          </label>
+          <label>ส่วนเบี่ยงเบนมาตรฐานของความต่าง (s_d)
+            <input type="number" id="sd-d" value="6.5" step="0.01" min="0" />
+          </label>
+          <label>จำนวนคู่ (n)
+            <input type="number" id="n-d" value="20" min="2" />
+          </label>
+        </div>
+        <label>ระดับนัยสำคัญ (α)
+          <input type="range" id="alpha" min="1" max="15" value="5" />
+        </label>
+        <div class="note">α = <span id="alpha-text">0.05</span></div>
+        <label>รูปแบบ H₁
+          <select id="tail">
+            <option value="two">≠</option>
+            <option value="right">></option>
+            <option value="left"><</option>
+          </select>
+        </label>
+        <button id="calc">คำนวณผล</button>
+      </div>
+      <div class="result-card" id="summary" style="display:none"></div>
+      <canvas id="diff-chart" height="220"></canvas>
+    </section>
+
+    <section class="card">
+      <h2>3. ตัวอย่างการตีความ</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>สถานการณ์</th>
+            <th>ข้อมูล</th>
+            <th>ผลลัพธ์</th>
+            <th>ข้อสรุป</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>ประสิทธิภาพสองสูตรยา (Welch)</td>
+            <td>t=2.43, df≈41.6, p=0.019</td>
+            <td>ปฏิเสธ H₀</td>
+            <td>สูตร A ให้ผลดีกว่า B อย่างมีนัยสำคัญ</td>
+          </tr>
+          <tr>
+            <td>คะแนนก่อน-หลังอบรม (paired)</td>
+            <td>t=3.12, df=18, p=0.006</td>
+            <td>ปฏิเสธ H₀</td>
+            <td>คะแนนหลังอบรมสูงขึ้นชัดเจน</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="card">
+      <h2>4. Checklist</h2>
+      <ul>
+        <li>✅ ระบุชนิดข้อมูล (อิสระ/จับคู่)</li>
+        <li>✅ ตรวจสอบเงื่อนไขความเป็นปกติและความแปรปรวน</li>
+        <li>✅ รายงาน t-stat, df, p-value และผลต่างเฉลี่ย</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.5/dist/jstat.min.js"></script>
+  <script>
+    const modeSelect = document.getElementById('mode');
+    const independentFields = document.getElementById('independent-fields');
+    const pairedFields = document.getElementById('paired-fields');
+    const mean1Input = document.getElementById('mean1');
+    const mean2Input = document.getElementById('mean2');
+    const sd1Input = document.getElementById('sd1');
+    const sd2Input = document.getElementById('sd2');
+    const n1Input = document.getElementById('n1');
+    const n2Input = document.getElementById('n2');
+    const meanDInput = document.getElementById('mean-d');
+    const sdDInput = document.getElementById('sd-d');
+    const nDInput = document.getElementById('n-d');
+    const alphaInput = document.getElementById('alpha');
+    const alphaText = document.getElementById('alpha-text');
+    const tailSelect = document.getElementById('tail');
+    const calcBtn = document.getElementById('calc');
+    const summary = document.getElementById('summary');
+    const ctx = document.getElementById('diff-chart');
+    let chart;
+
+    function toggleMode() {
+      if (modeSelect.value === 'paired') {
+        pairedFields.style.display = 'grid';
+        independentFields.style.display = 'none';
+      } else {
+        pairedFields.style.display = 'none';
+        independentFields.style.display = 'grid';
+      }
+    }
+
+    function welchDf(s1, s2, n1, n2) {
+      const t1 = (s1 * s1) / n1;
+      const t2 = (s2 * s2) / n2;
+      const num = Math.pow(t1 + t2, 2);
+      const den = (Math.pow(t1, 2) / (n1 - 1)) + (Math.pow(t2, 2) / (n2 - 1));
+      return num / den;
+    }
+
+    function pValue(stat, tail, df) {
+      if (tail === 'two') return 2 * (1 - jStat.studentt.cdf(Math.abs(stat), df));
+      if (tail === 'right') return 1 - jStat.studentt.cdf(stat, df);
+      return jStat.studentt.cdf(stat, df);
+    }
+
+    function critical(alpha, tail, df) {
+      return tail === 'two'
+        ? jStat.studentt.inv(1 - alpha / 2, df)
+        : jStat.studentt.inv(1 - alpha, df);
+    }
+
+    function updateChart(stat, crit, tail, df) {
+      const minX = -4;
+      const maxX = 4;
+      const points = 240;
+      const labels = [];
+      const base = [];
+      const highlight = [];
+      const statLine = [];
+      let lower;
+      let upper;
+      if (tail === 'two') {
+        lower = -crit;
+        upper = crit;
+      } else if (tail === 'right') {
+        lower = crit;
+        upper = maxX;
+      } else {
+        lower = minX;
+        upper = -crit;
+      }
+      for (let i = 0; i <= points; i += 1) {
+        const x = minX + ((maxX - minX) * i) / points;
+        const density = jStat.studentt.pdf(x, df);
+        labels.push(x.toFixed(2));
+        base.push(density);
+        const inCritical = tail === 'two' ? (x <= -crit || x >= crit) : (x >= lower && x <= upper);
+        highlight.push(inCritical ? density : null);
+        statLine.push(Math.abs(x - stat) < 0.02 ? density : null);
+      }
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: `t(df≈${df.toFixed(1)})`,
+              data: base,
+              borderColor: 'rgba(57,73,171,0.45)',
+              borderWidth: 2,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: false
+            },
+            {
+              label: 'พื้นที่วิกฤติ',
+              data: highlight,
+              borderColor: 'rgba(121,134,203,0.95)',
+              backgroundColor: 'rgba(121,134,203,0.35)',
+              borderWidth: 0,
+              pointRadius: 0,
+              fill: true
+            },
+            {
+              label: 'สถิติทดสอบ',
+              data: statLine,
+              borderColor: 'rgba(255,143,0,0.9)',
+              backgroundColor: 'rgba(255,213,79,0.65)',
+              borderWidth: 2,
+              pointRadius: 0,
+              fill: true
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { labels: { color: '#1a237e' } } },
+          scales: {
+            x: { title: { display: true, text: 't-statistic', color: '#1a237e' }, ticks: { color: '#1a237e' } },
+            y: { title: { display: true, text: 'ความหนาแน่น', color: '#1a237e' }, ticks: { color: '#1a237e' } }
+          }
+        }
+      });
+    }
+
+    function calculate() {
+      const alpha = parseInt(alphaInput.value, 10) / 100;
+      alphaText.textContent = alpha.toFixed(2);
+      const tail = tailSelect.value;
+      let stat;
+      let df;
+      let se;
+      let diff;
+
+      if (modeSelect.value === 'paired') {
+        const meanD = parseFloat(meanDInput.value);
+        const sdD = Math.max(parseFloat(sdDInput.value), 1e-6);
+        const n = Math.max(parseInt(nDInput.value, 10), 2);
+        nDInput.value = n;
+        diff = meanD;
+        se = sdD / Math.sqrt(n);
+        stat = diff / se;
+        df = n - 1;
+      } else {
+        const mean1 = parseFloat(mean1Input.value);
+        const mean2 = parseFloat(mean2Input.value);
+        const sd1 = Math.max(parseFloat(sd1Input.value), 1e-6);
+        const sd2 = Math.max(parseFloat(sd2Input.value), 1e-6);
+        const n1 = Math.max(parseInt(n1Input.value, 10), 2);
+        const n2 = Math.max(parseInt(n2Input.value, 10), 2);
+        n1Input.value = n1;
+        n2Input.value = n2;
+        diff = mean1 - mean2;
+        if (modeSelect.value === 'pooled') {
+          const sp2 = (((n1 - 1) * sd1 * sd1) + ((n2 - 1) * sd2 * sd2)) / (n1 + n2 - 2);
+          const sp = Math.sqrt(sp2);
+          se = sp * Math.sqrt(1 / n1 + 1 / n2);
+          stat = diff / se;
+          df = n1 + n2 - 2;
+        } else {
+          se = Math.sqrt((sd1 * sd1) / n1 + (sd2 * sd2) / n2);
+          stat = diff / se;
+          df = welchDf(sd1, sd2, n1, n2);
+        }
+      }
+
+      const crit = critical(alpha, tail, df);
+      const p = pValue(stat, tail, df);
+      const reject = tail === 'two' ? Math.abs(stat) > crit : (tail === 'right' ? stat > crit : stat < -crit);
+
+      summary.style.display = 'grid';
+      summary.innerHTML = `
+        <strong>ผลการทดสอบ</strong>
+        <span>t = ${stat.toFixed(3)} | df ≈ ${df.toFixed(2)} | SE = ${se.toFixed(3)}</span>
+        <span>Critical = ${tail === 'two' ? '±' : ''}${crit.toFixed(3)} | p-value = ${p.toFixed(4)}</span>
+        <span>การตัดสินใจ: ${reject ? '<strong style="color:#c62828">ปฏิเสธ H₀</strong>' : '<strong style="color:#2e7d32">ยังไม่ปฏิเสธ H₀</strong>'}</span>
+      `;
+
+      updateChart(stat, crit, tail, df);
+    }
+
+    modeSelect.addEventListener('change', () => {
+      toggleMode();
+      calculate();
+    });
+    [mean1Input, mean2Input, sd1Input, sd2Input, n1Input, n2Input, meanDInput, sdDInput, nDInput, tailSelect].forEach(el => {
+      el.addEventListener('input', calculate);
+    });
+    alphaInput.addEventListener('input', calculate);
+    calcBtn.addEventListener('click', calculate);
+
+    toggleMode();
+    calculate();
+  </script>
+</body>
+</html>

--- a/prob & Stats/content/28-ht-two-proportions.html
+++ b/prob & Stats/content/28-ht-two-proportions.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8" />
+  <title>บทที่ 28: การทดสอบผลต่างสัดส่วนสองประชากร</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      --accent: #00796b;
+      --accent-light: #4db6ac;
+      --accent-dark: #004d40;
+      --card-bg: rgba(224, 242, 241, 0.94);
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+      min-height: 100vh;
+      background: radial-gradient(circle at 15% 18%, rgba(77, 182, 172, 0.25), transparent 60%),
+                  radial-gradient(circle at 80% 18%, rgba(0, 121, 107, 0.2), transparent 60%),
+                  linear-gradient(180deg, rgba(224, 242, 241, 0.92), rgba(232, 245, 243, 0.9));
+    }
+    main.container { max-width: 1100px; margin: 0 auto; padding: clamp(2rem, 5vw, 3.5rem); display: grid; gap: 2.2rem; }
+    header.hero { background: linear-gradient(135deg, var(--accent), var(--accent-light)); color: #fff; padding: clamp(2.6rem, 6vw, 4rem); border-radius: 32px; position: relative; overflow: hidden; box-shadow: 0 32px 54px rgba(0, 77, 64, 0.24); }
+    header.hero::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 78% 18%, rgba(255,255,255,0.4), transparent 55%), radial-gradient(circle at 20% 75%, rgba(255,255,255,0.24), transparent 70%); }
+    header.hero h1 { font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem); margin-bottom: 0.75rem; }
+    header.hero p { font-size: 1.12rem; max-width: 720px; line-height: 1.7; }
+    section.card { background: var(--card-bg); border-radius: 26px; padding: clamp(1.8rem, 4vw, 2.6rem); box-shadow: 0 20px 36px rgba(0, 77, 64, 0.14); backdrop-filter: blur(6px); display: grid; gap: 1.1rem; }
+    section.card h2 { color: var(--accent-dark); font-size: 1.9rem; display: flex; align-items: center; gap: 0.75rem; margin: 0; }
+    .badge { background: rgba(0, 121, 107, 0.2); color: var(--accent-dark); padding: 0.2rem 0.85rem; border-radius: 999px; font-size: 0.9rem; font-weight: 600; }
+    .grid { display: grid; gap: 1.2rem; }
+    @media (min-width: 960px) { .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    article.definition { padding: 1.35rem 1.6rem; border-radius: 20px; background: rgba(200, 230, 201, 0.85); border: 1px solid rgba(0, 121, 107, 0.18); display: grid; gap: 0.6rem; }
+    article.definition strong { color: var(--accent-dark); font-size: 1.05rem; }
+    .highlight { border-left: 6px solid var(--accent); padding: 1rem 1.25rem; background: rgba(0, 150, 136, 0.12); border-radius: 18px; line-height: 1.7; }
+    .calculator { display: grid; gap: 1rem; margin-top: 0.8rem; }
+    .calculator label { font-weight: 600; color: var(--accent-dark); display: grid; gap: 0.4rem; }
+    .calculator input, .calculator select { padding: 0.75rem 1rem; border-radius: 14px; border: 1px solid rgba(0, 121, 107, 0.28); font-size: 1rem; background: rgba(255,255,255,0.95); }
+    .calculator button { background: linear-gradient(135deg, var(--accent-dark), var(--accent)); color: #fff; border: 0; border-radius: 14px; padding: 0.85rem 1.2rem; font-size: 1rem; font-weight: 600; cursor: pointer; transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .calculator button:hover { transform: translateY(-2px); box-shadow: 0 16px 30px rgba(0, 121, 107, 0.2); }
+    .result-card { background: rgba(255,255,255,0.95); border-radius: 18px; padding: 1.2rem 1.4rem; border: 1px solid rgba(0, 150, 136, 0.2); display: grid; gap: 0.6rem; }
+    canvas { background: rgba(255,255,255,0.88); border-radius: 18px; padding: 1rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.6rem 0.75rem; text-align: left; }
+    th { background: rgba(200, 230, 201, 0.6); color: var(--accent-dark); }
+    tr:nth-child(even) { background: rgba(224, 242, 241, 0.6); }
+  </style>
+</head>
+<body class="page">
+  <main class="container">
+    <header class="hero">
+      <span class="badge">Two-sample Proportion Test</span>
+      <h1>บทที่ 28: การทดสอบผลต่างสัดส่วนสองประชากร (p₁ − p₂)</h1>
+      <p>ใช้การแจกแจงปกติแบบ pooled เพื่อตรวจสอบว่าสัดส่วนของสองกลุ่มมีความแตกต่างกันหรือไม่.</p>
+    </header>
+
+    <section class="card">
+      <h2>1. สมมติฐาน</h2>
+      <div class="grid two">
+        <article class="definition">
+          <strong>H₀</strong>
+          <p>\(p_1 = p_2\) หรือ \(p_1 - p_2 = 0\)</p>
+        </article>
+        <article class="definition">
+          <strong>H₁</strong>
+          <p>เลือก >, < หรือ ≠ ตามโจทย์</p>
+        </article>
+      </div>
+      <div class="highlight">คำนวณส่วนเบี่ยงเบนมาตรฐานด้วยสัดส่วนรวม (pooled): \(\hat{p} = \frac{x_1 + x_2}{n_1 + n_2}\)</div>
+    </section>
+
+    <section class="card">
+      <h2>2. เครื่องมือคำนวณ</h2>
+      <div class="calculator">
+        <div class="grid two">
+          <div>
+            <label>x₁
+              <input type="number" id="x1" value="120" min="0" />
+            </label>
+            <label>n₁
+              <input type="number" id="n1" value="320" min="1" />
+            </label>
+          </div>
+          <div>
+            <label>x₂
+              <input type="number" id="x2" value="95" min="0" />
+            </label>
+            <label>n₂
+              <input type="number" id="n2" value="260" min="1" />
+            </label>
+          </div>
+        </div>
+        <label>ระดับนัยสำคัญ (α)
+          <input type="range" id="alpha" min="1" max="15" value="5" />
+        </label>
+        <div class="note">α = <span id="alpha-text">0.05</span></div>
+        <label>รูปแบบ H₁
+          <select id="tail">
+            <option value="two">≠</option>
+            <option value="right">></option>
+            <option value="left"><</option>
+          </select>
+        </label>
+        <button id="calc">คำนวณผล</button>
+      </div>
+      <div class="result-card" id="summary" style="display:none"></div>
+      <canvas id="diff-chart" height="220"></canvas>
+    </section>
+
+    <section class="card">
+      <h2>3. ตัวอย่างการตีความ</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>สถานการณ์</th>
+            <th>ข้อมูล</th>
+            <th>ผลลัพธ์</th>
+            <th>ข้อสรุป</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>แคมเปญ A vs B</td>
+            <td>z=2.34, p=0.019</td>
+            <td>ปฏิเสธ H₀</td>
+            <td>แคมเปญ A มีอัตราตอบรับสูงกว่า B</td>
+          </tr>
+          <tr>
+            <td>อัตราสอบผ่านสองห้องเรียน</td>
+            <td>z=0.92, p=0.357</td>
+            <td>ยังไม่ปฏิเสธ H₀</td>
+            <td>หลักฐานไม่พอว่ามีความแตกต่าง</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="card">
+      <h2>4. Checklist</h2>
+      <ul>
+        <li>✅ ตรวจสอบ np̂ และ n(1-p̂) ทั้งสองกลุ่ม ≥ 10</li>
+        <li>✅ ใช้สัดส่วน pooled สำหรับการทดสอบ</li>
+        <li>✅ รายงานทั้ง z, p-value และความต่าง \(\hat{p}_1 - \hat{p}_2\)</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.5/dist/jstat.min.js"></script>
+  <script>
+    const x1Input = document.getElementById('x1');
+    const n1Input = document.getElementById('n1');
+    const x2Input = document.getElementById('x2');
+    const n2Input = document.getElementById('n2');
+    const alphaInput = document.getElementById('alpha');
+    const alphaText = document.getElementById('alpha-text');
+    const tailSelect = document.getElementById('tail');
+    const calcBtn = document.getElementById('calc');
+    const summary = document.getElementById('summary');
+    const ctx = document.getElementById('diff-chart');
+    let chart;
+
+    function critical(alpha, tail) {
+      return tail === 'two'
+        ? jStat.normal.inv(1 - alpha / 2, 0, 1)
+        : jStat.normal.inv(1 - alpha, 0, 1);
+    }
+
+    function pValue(stat, tail) {
+      if (tail === 'two') return 2 * (1 - jStat.normal.cdf(Math.abs(stat), 0, 1));
+      if (tail === 'right') return 1 - jStat.normal.cdf(stat, 0, 1);
+      return jStat.normal.cdf(stat, 0, 1);
+    }
+
+    function updateChart(stat, crit, tail) {
+      const minX = -4;
+      const maxX = 4;
+      const points = 240;
+      const labels = [];
+      const base = [];
+      const highlight = [];
+      const statLine = [];
+      let lower;
+      let upper;
+      if (tail === 'two') {
+        lower = -crit;
+        upper = crit;
+      } else if (tail === 'right') {
+        lower = crit;
+        upper = maxX;
+      } else {
+        lower = minX;
+        upper = -crit;
+      }
+      for (let i = 0; i <= points; i += 1) {
+        const x = minX + ((maxX - minX) * i) / points;
+        const density = jStat.normal.pdf(x, 0, 1);
+        labels.push(x.toFixed(2));
+        base.push(density);
+        const inCritical = tail === 'two' ? (x <= -crit || x >= crit) : (x >= lower && x <= upper);
+        highlight.push(inCritical ? density : null);
+        statLine.push(Math.abs(x - stat) < 0.02 ? density : null);
+      }
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'มาตรฐานปกติ',
+              data: base,
+              borderColor: 'rgba(0,121,107,0.45)',
+              borderWidth: 2,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: false
+            },
+            {
+              label: 'พื้นที่วิกฤติ',
+              data: highlight,
+              borderColor: 'rgba(77,182,172,0.95)',
+              backgroundColor: 'rgba(77,182,172,0.35)',
+              borderWidth: 0,
+              pointRadius: 0,
+              fill: true
+            },
+            {
+              label: 'สถิติทดสอบ',
+              data: statLine,
+              borderColor: 'rgba(255,112,67,0.9)',
+              backgroundColor: 'rgba(255,171,64,0.6)',
+              borderWidth: 2,
+              pointRadius: 0,
+              fill: true
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { labels: { color: '#004d40' } } },
+          scales: {
+            x: { title: { display: true, text: 'z-statistic', color: '#004d40' }, ticks: { color: '#004d40' } },
+            y: { title: { display: true, text: 'ความหนาแน่น', color: '#004d40' }, ticks: { color: '#004d40' } }
+          }
+        }
+      });
+    }
+
+    function calculate() {
+      const x1 = Math.max(parseInt(x1Input.value, 10), 0);
+      const n1 = Math.max(parseInt(n1Input.value, 10), 1);
+      const x2 = Math.max(parseInt(x2Input.value, 10), 0);
+      const n2 = Math.max(parseInt(n2Input.value, 10), 1);
+      x1Input.value = x1; n1Input.value = n1; x2Input.value = x2; n2Input.value = n2;
+      const alpha = parseInt(alphaInput.value, 10) / 100;
+      alphaText.textContent = alpha.toFixed(2);
+      const tail = tailSelect.value;
+      const phat1 = x1 / n1;
+      const phat2 = x2 / n2;
+      const pooled = (x1 + x2) / (n1 + n2);
+      const se = Math.sqrt(pooled * (1 - pooled) * (1 / n1 + 1 / n2));
+      const stat = (phat1 - phat2) / se;
+      const crit = critical(alpha, tail);
+      const p = pValue(stat, tail);
+      const reject = tail === 'two' ? Math.abs(stat) > crit : (tail === 'right' ? stat > crit : stat < -crit);
+
+      summary.style.display = 'grid';
+      summary.innerHTML = `
+        <strong>ผลการทดสอบ</strong>
+        <span>\u005Chat{p}_1 = ${(phat1 * 100).toFixed(2)}%, \u005Chat{p}_2 = ${(phat2 * 100).toFixed(2)}%</span>
+        <span>pooled \u005Chat{p} = ${(pooled * 100).toFixed(2)}%</span>
+        <span>z = ${stat.toFixed(3)} | Critical = ${tail === 'two' ? '±' : ''}${crit.toFixed(3)} | p-value = ${p.toFixed(4)}</span>
+        <span>การตัดสินใจ: ${reject ? '<strong style="color:#c62828">ปฏิเสธ H₀</strong>' : '<strong style="color:#2e7d32">ยังไม่ปฏิเสธ H₀</strong>'}</span>
+      `;
+
+      updateChart(stat, crit, tail);
+    }
+
+    [x1Input, n1Input, x2Input, n2Input, tailSelect].forEach(el => el.addEventListener('input', calculate));
+    alphaInput.addEventListener('input', calculate);
+    calcBtn.addEventListener('click', calculate);
+
+    calculate();
+  </script>
+</body>
+</html>

--- a/prob & Stats/content/29-ht-one-variance.html
+++ b/prob & Stats/content/29-ht-one-variance.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8" />
+  <title>บทที่ 29: การทดสอบความแปรปรวนประชากรเดียว</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      --accent: #8e24aa;
+      --accent-light: #ce93d8;
+      --accent-dark: #6a1b9a;
+      --card-bg: rgba(243, 229, 245, 0.94);
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+      min-height: 100vh;
+      background: radial-gradient(circle at 15% 18%, rgba(206,147,216,0.28), transparent 60%),
+                  radial-gradient(circle at 80% 18%, rgba(142,36,170,0.2), transparent 60%),
+                  linear-gradient(180deg, rgba(237,231,246,0.92), rgba(243,229,245,0.9));
+    }
+    main.container { max-width: 1100px; margin: 0 auto; padding: clamp(2rem, 5vw, 3.5rem); display: grid; gap: 2.2rem; }
+    header.hero { background: linear-gradient(135deg, var(--accent), var(--accent-light)); color: #fff; padding: clamp(2.6rem, 6vw, 4rem); border-radius: 32px; position: relative; overflow: hidden; box-shadow: 0 32px 54px rgba(106,27,154,0.24); }
+    header.hero::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 78% 18%, rgba(255,255,255,0.42), transparent 55%), radial-gradient(circle at 20% 75%, rgba(255,255,255,0.24), transparent 70%); }
+    header.hero h1 { font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem); margin-bottom: 0.75rem; }
+    header.hero p { font-size: 1.12rem; max-width: 720px; line-height: 1.7; }
+    section.card { background: var(--card-bg); border-radius: 26px; padding: clamp(1.8rem, 4vw, 2.6rem); box-shadow: 0 20px 36px rgba(106,27,154,0.14); backdrop-filter: blur(6px); display: grid; gap: 1.1rem; }
+    section.card h2 { color: var(--accent-dark); font-size: 1.9rem; display: flex; align-items: center; gap: 0.75rem; margin: 0; }
+    .badge { background: rgba(142,36,170,0.2); color: var(--accent-dark); padding: 0.2rem 0.85rem; border-radius: 999px; font-size: 0.9rem; font-weight: 600; }
+    .calculator { display: grid; gap: 1rem; margin-top: 0.8rem; }
+    .calculator label { font-weight: 600; color: var(--accent-dark); display: grid; gap: 0.4rem; }
+    .calculator input, .calculator select { padding: 0.75rem 1rem; border-radius: 14px; border: 1px solid rgba(142,36,170,0.28); font-size: 1rem; background: rgba(255,255,255,0.95); }
+    .calculator button { background: linear-gradient(135deg, var(--accent-dark), var(--accent)); color: #fff; border: 0; border-radius: 14px; padding: 0.85rem 1.2rem; font-size: 1rem; font-weight: 600; cursor: pointer; transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .calculator button:hover { transform: translateY(-2px); box-shadow: 0 16px 30px rgba(106,27,154,0.2); }
+    .result-card { background: rgba(255,255,255,0.95); border-radius: 18px; padding: 1.2rem 1.4rem; border: 1px solid rgba(142,36,170,0.18); display: grid; gap: 0.6rem; }
+    canvas { background: rgba(255,255,255,0.88); border-radius: 18px; padding: 1rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.6rem 0.75rem; text-align: left; }
+    th { background: rgba(206,147,216,0.6); color: var(--accent-dark); }
+    tr:nth-child(even) { background: rgba(243,229,245,0.6); }
+  </style>
+</head>
+<body class="page">
+  <main class="container">
+    <header class="hero">
+      <span class="badge">Chi-square Test</span>
+      <h1>บทที่ 29: การทดสอบความแปรปรวนประชากรเดียว (σ²)</h1>
+      <p>ใช้สถิติไคสแควร์เพื่อตรวจสอบว่าความแปรปรวนของประชากรเท่ากับค่าที่คาดไว้หรือไม่ เหมาะกับข้อมูลที่ใกล้เคียงปกติ.</p>
+    </header>
+
+    <section class="card">
+      <h2>1. สมมติฐาน</h2>
+      <p>\(H_0: \sigma^2 = \sigma_0^2\)</p>
+      <p>สถิติทดสอบ: \( \chi^2 = \frac{(n-1)s^2}{\sigma_0^2} \) ซึ่งมี df = n-1</p>
+    </section>
+
+    <section class="card">
+      <h2>2. เครื่องมือคำนวณ</h2>
+      <div class="calculator">
+        <label>ส่วนเบี่ยงเบนมาตรฐานตัวอย่าง (s)
+          <input type="number" id="sd" value="6.2" step="0.01" min="0" />
+        </label>
+        <label>ส่วนเบี่ยงเบนมาตรฐานตาม H₀ (σ₀)
+          <input type="number" id="sd0" value="5" step="0.01" min="0" />
+        </label>
+        <label>ขนาดตัวอย่าง (n)
+          <input type="number" id="n" value="18" min="2" />
+        </label>
+        <label>ระดับนัยสำคัญ (α)
+          <input type="range" id="alpha" min="1" max="15" value="5" />
+        </label>
+        <div class="note">α = <span id="alpha-text">0.05</span></div>
+        <label>รูปแบบ H₁
+          <select id="tail">
+            <option value="two">≠</option>
+            <option value="right">> (σ² มากกว่า)</option>
+            <option value="left">< (σ² น้อยกว่า)</option>
+          </select>
+        </label>
+        <button id="calc">คำนวณผล</button>
+      </div>
+      <div class="result-card" id="summary" style="display:none"></div>
+      <canvas id="chi-chart" height="220"></canvas>
+    </section>
+
+    <section class="card">
+      <h2>3. ตัวอย่าง</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>สถานการณ์</th>
+            <th>ข้อมูล</th>
+            <th>ผล</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>ความเสถียรเครื่องจักร</td>
+            <td>χ²=24.6, df=15, p=0.109 (two-tailed)</td>
+            <td>ยังไม่ปฏิเสธ H₀</td>
+          </tr>
+          <tr>
+            <td>ความผันผวนของกระบวนการ</td>
+            <td>χ²=36.2, df=18, p=0.013 (right-tailed)</td>
+            <td>ปฏิเสธ H₀ → ความแปรปรวนสูงกว่ามาตรฐาน</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="card">
+      <h2>4. Checklist</h2>
+      <ul>
+        <li>✅ ข้อมูลมาจากประชากรปกติ</li>
+        <li>✅ ไม่มี outlier รุนแรง</li>
+        <li>✅ ระบุรูปแบบ tail และ df อย่างชัดเจน</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.5/dist/jstat.min.js"></script>
+  <script>
+    const sdInput = document.getElementById('sd');
+    const sd0Input = document.getElementById('sd0');
+    const nInput = document.getElementById('n');
+    const alphaInput = document.getElementById('alpha');
+    const alphaText = document.getElementById('alpha-text');
+    const tailSelect = document.getElementById('tail');
+    const calcBtn = document.getElementById('calc');
+    const summary = document.getElementById('summary');
+    const ctx = document.getElementById('chi-chart');
+    let chart;
+
+    function critical(alpha, tail, df) {
+      if (tail === 'two') {
+        return {
+          lower: jStat.chisquare.inv(alpha / 2, df),
+          upper: jStat.chisquare.inv(1 - alpha / 2, df)
+        };
+      }
+      if (tail === 'right') {
+        return { lower: jStat.chisquare.inv(alpha, df), upper: jStat.chisquare.inv(1 - alpha, df) };
+      }
+      return { lower: jStat.chisquare.inv(alpha, df), upper: jStat.chisquare.inv(1 - alpha, df) };
+    }
+
+    function pValue(stat, tail, df) {
+      if (tail === 'two') {
+        const upperTail = 1 - jStat.chisquare.cdf(stat, df);
+        const lowerTail = jStat.chisquare.cdf(stat, df);
+        return stat > df ? 2 * upperTail : 2 * lowerTail;
+      }
+      if (tail === 'right') {
+        return 1 - jStat.chisquare.cdf(stat, df);
+      }
+      return jStat.chisquare.cdf(stat, df);
+    }
+
+    function updateChart(stat, critBounds, tail, df) {
+      const maxX = Math.max(critBounds.upper * 1.1, stat * 1.1, df + 4 * Math.sqrt(2 * df));
+      const points = 240;
+      const labels = [];
+      const base = [];
+      const highlight = [];
+      const statLine = [];
+      for (let i = 0; i <= points; i += 1) {
+        const x = (maxX * i) / points;
+        const density = jStat.chisquare.pdf(x, df);
+        labels.push(x.toFixed(2));
+        base.push(density);
+        let inCritical = false;
+        if (tail === 'two') {
+          inCritical = x <= critBounds.lower || x >= critBounds.upper;
+        } else if (tail === 'right') {
+          inCritical = x >= critBounds.upper;
+        } else {
+          inCritical = x <= critBounds.lower;
+        }
+        highlight.push(inCritical ? density : null);
+        statLine.push(Math.abs(x - stat) < maxX / points ? density : null);
+      }
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: `χ²(df=${df})`,
+              data: base,
+              borderColor: 'rgba(106,27,154,0.45)',
+              borderWidth: 2,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: false
+            },
+            {
+              label: 'พื้นที่วิกฤติ',
+              data: highlight,
+              borderColor: 'rgba(171,71,188,0.95)',
+              backgroundColor: 'rgba(171,71,188,0.35)',
+              borderWidth: 0,
+              pointRadius: 0,
+              fill: true
+            },
+            {
+              label: 'สถิติทดสอบ',
+              data: statLine,
+              borderColor: 'rgba(255,112,67,0.9)',
+              backgroundColor: 'rgba(255,183,77,0.6)',
+              borderWidth: 2,
+              pointRadius: 0,
+              fill: true
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { labels: { color: '#6a1b9a' } } },
+          scales: {
+            x: { title: { display: true, text: 'χ²', color: '#6a1b9a' }, ticks: { color: '#6a1b9a' } },
+            y: { title: { display: true, text: 'ความหนาแน่น', color: '#6a1b9a' }, ticks: { color: '#6a1b9a' } }
+          }
+        }
+      });
+    }
+
+    function calculate() {
+      const s = Math.max(parseFloat(sdInput.value), 1e-6);
+      const s0 = Math.max(parseFloat(sd0Input.value), 1e-6);
+      const n = Math.max(parseInt(nInput.value, 10), 2);
+      nInput.value = n;
+      const df = n - 1;
+      const alpha = parseInt(alphaInput.value, 10) / 100;
+      alphaText.textContent = alpha.toFixed(2);
+      const tail = tailSelect.value;
+      const stat = (df * s * s) / (s0 * s0);
+      const critBounds = critical(alpha, tail, df);
+      const p = pValue(stat, tail, df);
+      let reject;
+      if (tail === 'two') {
+        reject = stat <= critBounds.lower || stat >= critBounds.upper;
+      } else if (tail === 'right') {
+        reject = stat >= critBounds.upper;
+      } else {
+        reject = stat <= critBounds.lower;
+      }
+
+      summary.style.display = 'grid';
+      summary.innerHTML = `
+        <strong>ผลการทดสอบ</strong>
+        <span>χ² = ${stat.toFixed(3)} | df = ${df}</span>
+        <span>Critical bounds: [${critBounds.lower.toFixed(3)}, ${critBounds.upper.toFixed(3)}]</span>
+        <span>p-value ≈ ${p.toFixed(4)}</span>
+        <span>การตัดสินใจ: ${reject ? '<strong style="color:#c62828">ปฏิเสธ H₀</strong>' : '<strong style="color:#2e7d32">ยังไม่ปฏิเสธ H₀</strong>'}</span>
+      `;
+
+      updateChart(stat, critBounds, tail, df);
+    }
+
+    [sdInput, sd0Input, nInput, tailSelect].forEach(el => el.addEventListener('input', calculate));
+    alphaInput.addEventListener('input', calculate);
+    calcBtn.addEventListener('click', calculate);
+
+    calculate();
+  </script>
+</body>
+</html>

--- a/prob & Stats/content/30-ht-variance-ratio.html
+++ b/prob & Stats/content/30-ht-variance-ratio.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8" />
+  <title>บทที่ 30: การทดสอบอัตราส่วนความแปรปรวน (F-test)</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      --accent: #0069c0;
+      --accent-light: #64b5f6;
+      --accent-dark: #01579b;
+      --card-bg: rgba(227, 242, 253, 0.94);
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+      min-height: 100vh;
+      background: radial-gradient(circle at 15% 18%, rgba(100,181,246,0.28), transparent 60%),
+                  radial-gradient(circle at 80% 18%, rgba(0,105,192,0.2), transparent 60%),
+                  linear-gradient(180deg, rgba(225,245,254,0.92), rgba(232,245,255,0.9));
+    }
+    main.container { max-width: 1100px; margin: 0 auto; padding: clamp(2rem, 5vw, 3.5rem); display: grid; gap: 2.2rem; }
+    header.hero { background: linear-gradient(135deg, var(--accent), var(--accent-light)); color: #fff; padding: clamp(2.6rem, 6vw, 4rem); border-radius: 32px; position: relative; overflow: hidden; box-shadow: 0 32px 54px rgba(1,87,155,0.24); }
+    header.hero::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 78% 18%, rgba(255,255,255,0.4), transparent 55%), radial-gradient(circle at 20% 75%, rgba(255,255,255,0.24), transparent 70%); }
+    header.hero h1 { font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem); margin-bottom: 0.75rem; }
+    header.hero p { font-size: 1.12rem; max-width: 720px; line-height: 1.7; }
+    section.card { background: var(--card-bg); border-radius: 26px; padding: clamp(1.8rem, 4vw, 2.6rem); box-shadow: 0 20px 36px rgba(1,87,155,0.14); backdrop-filter: blur(6px); display: grid; gap: 1.1rem; }
+    section.card h2 { color: var(--accent-dark); font-size: 1.9rem; display: flex; align-items: center; gap: 0.75rem; margin: 0; }
+    .badge { background: rgba(0,105,192,0.16); color: var(--accent-dark); padding: 0.2rem 0.85rem; border-radius: 999px; font-size: 0.9rem; font-weight: 600; }
+    .calculator { display: grid; gap: 1rem; margin-top: 0.8rem; }
+    .calculator label { font-weight: 600; color: var(--accent-dark); display: grid; gap: 0.4rem; }
+    .calculator input, .calculator select { padding: 0.75rem 1rem; border-radius: 14px; border: 1px solid rgba(1,105,205,0.28); font-size: 1rem; background: rgba(255,255,255,0.95); }
+    .calculator button { background: linear-gradient(135deg, var(--accent-dark), var(--accent)); color: #fff; border: 0; border-radius: 14px; padding: 0.85rem 1.2rem; font-size: 1rem; font-weight: 600; cursor: pointer; transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .calculator button:hover { transform: translateY(-2px); box-shadow: 0 16px 30px rgba(1,87,155,0.22); }
+    .result-card { background: rgba(255,255,255,0.95); border-radius: 18px; padding: 1.2rem 1.4rem; border: 1px solid rgba(1,87,155,0.18); display: grid; gap: 0.6rem; }
+    canvas { background: rgba(255,255,255,0.88); border-radius: 18px; padding: 1rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.6rem 0.75rem; text-align: left; }
+    th { background: rgba(187,222,251,0.6); color: var(--accent-dark); }
+    tr:nth-child(even) { background: rgba(225,245,254,0.6); }
+  </style>
+</head>
+<body class="page">
+  <main class="container">
+    <header class="hero">
+      <span class="badge">F-test</span>
+      <h1>บทที่ 30: การทดสอบอัตราส่วนความแปรปรวน (F-test)</h1>
+      <p>ใช้สำหรับเปรียบเทียบความแปรปรวนของสองประชากร โดยสมมติฐานพื้นฐานคือข้อมูลทั้งสองกลุ่มมาจากประชากรปกติ.</p>
+    </header>
+
+    <section class="card">
+      <h2>1. สมมติฐาน</h2>
+      <p>\(H_0: \sigma_1^2 = \sigma_2^2\)</p>
+      <p>สถิติทดสอบ: \( F = \frac{s_1^2}{s_2^2} \) (โดยกำหนดให้ s₁² ≥ s₂² หรือระบุอัตราส่วนที่คาดไว้)</p>
+    </section>
+
+    <section class="card">
+      <h2>2. เครื่องมือคำนวณ</h2>
+      <div class="calculator">
+        <div class="grid two">
+          <div>
+            <label>s₁
+              <input type="number" id="sd1" value="9.2" step="0.01" min="0" />
+            </label>
+            <label>n₁
+              <input type="number" id="n1" value="25" min="2" />
+            </label>
+          </div>
+          <div>
+            <label>s₂
+              <input type="number" id="sd2" value="7.5" step="0.01" min="0" />
+            </label>
+            <label>n₂
+              <input type="number" id="n2" value="22" min="2" />
+            </label>
+          </div>
+        </div>
+        <label>อัตราส่วนที่คาด (\(\sigma_1^2/\sigma_2^2\))
+          <input type="number" id="ratio" value="1" step="0.01" min="0.0001" />
+        </label>
+        <label>ระดับนัยสำคัญ (α)
+          <input type="range" id="alpha" min="1" max="15" value="5" />
+        </label>
+        <div class="note">α = <span id="alpha-text">0.05</span></div>
+        <label>รูปแบบ H₁
+          <select id="tail">
+            <option value="two">≠</option>
+            <option value="right">> (σ₁²/σ₂² มากกว่า ratio)</option>
+            <option value="left">< (σ₁²/σ₂² น้อยกว่า ratio)</option>
+          </select>
+        </label>
+        <button id="calc">คำนวณผล</button>
+      </div>
+      <div class="result-card" id="summary" style="display:none"></div>
+      <canvas id="f-chart" height="220"></canvas>
+    </section>
+
+    <section class="card">
+      <h2>3. Checklist</h2>
+      <ul>
+        <li>✅ ทั้งสองกลุ่มมาจากประชากรปกติ</li>
+        <li>✅ กำหนดว่า σ₁² เป็นของกลุ่มใด (ควรเลือกกลุ่มที่มี s² มากกว่า)</li>
+        <li>✅ รายงาน F, df₁, df₂, p-value</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jstat@1.9.5/dist/jstat.min.js"></script>
+  <script>
+    const sd1Input = document.getElementById('sd1');
+    const n1Input = document.getElementById('n1');
+    const sd2Input = document.getElementById('sd2');
+    const n2Input = document.getElementById('n2');
+    const ratioInput = document.getElementById('ratio');
+    const alphaInput = document.getElementById('alpha');
+    const alphaText = document.getElementById('alpha-text');
+    const tailSelect = document.getElementById('tail');
+    const calcBtn = document.getElementById('calc');
+    const summary = document.getElementById('summary');
+    const ctx = document.getElementById('f-chart');
+    let chart;
+
+    function critical(alpha, tail, df1, df2) {
+      if (tail === 'two') {
+        return {
+          lower: jStat.centralF.inv(alpha / 2, df1, df2),
+          upper: jStat.centralF.inv(1 - alpha / 2, df1, df2)
+        };
+      }
+      if (tail === 'right') {
+        return {
+          lower: jStat.centralF.inv(alpha, df1, df2),
+          upper: jStat.centralF.inv(1 - alpha, df1, df2)
+        };
+      }
+      return {
+        lower: jStat.centralF.inv(alpha, df1, df2),
+        upper: jStat.centralF.inv(1 - alpha, df1, df2)
+      };
+    }
+
+    function pValue(stat, tail, df1, df2) {
+      if (tail === 'two') {
+        const upperTail = 1 - jStat.centralF.cdf(stat, df1, df2);
+        const lowerTail = jStat.centralF.cdf(stat, df1, df2);
+        return stat > 1 ? 2 * upperTail : 2 * lowerTail;
+      }
+      if (tail === 'right') {
+        return 1 - jStat.centralF.cdf(stat, df1, df2);
+      }
+      return jStat.centralF.cdf(stat, df1, df2);
+    }
+
+    function updateChart(stat, critBounds, tail, df1, df2) {
+      const maxX = Math.max(critBounds.upper * 1.3, stat * 1.2, 5);
+      const points = 240;
+      const labels = [];
+      const base = [];
+      const highlight = [];
+      const statLine = [];
+      for (let i = 0; i <= points; i += 1) {
+        const x = (maxX * i) / points;
+        const density = jStat.centralF.pdf(x, df1, df2);
+        labels.push(x.toFixed(2));
+        base.push(density);
+        let inCritical = false;
+        if (tail === 'two') {
+          inCritical = x <= critBounds.lower || x >= critBounds.upper;
+        } else if (tail === 'right') {
+          inCritical = x >= critBounds.upper;
+        } else {
+          inCritical = x <= critBounds.lower;
+        }
+        highlight.push(inCritical ? density : null);
+        statLine.push(Math.abs(x - stat) < maxX / points ? density : null);
+      }
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: `F(df₁=${df1}, df₂=${df2})`,
+              data: base,
+              borderColor: 'rgba(1,87,155,0.45)',
+              borderWidth: 2,
+              tension: 0.22,
+              pointRadius: 0,
+              fill: false
+            },
+            {
+              label: 'พื้นที่วิกฤติ',
+              data: highlight,
+              borderColor: 'rgba(79,195,247,0.95)',
+              backgroundColor: 'rgba(129,212,250,0.35)',
+              borderWidth: 0,
+              pointRadius: 0,
+              fill: true
+            },
+            {
+              label: 'สถิติทดสอบ',
+              data: statLine,
+              borderColor: 'rgba(255,143,0,0.9)',
+              backgroundColor: 'rgba(255,183,77,0.6)',
+              borderWidth: 2,
+              pointRadius: 0,
+              fill: true
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { labels: { color: '#01579b' } } },
+          scales: {
+            x: { title: { display: true, text: 'ค่า F', color: '#01579b' }, ticks: { color: '#01579b' } },
+            y: { title: { display: true, text: 'ความหนาแน่น', color: '#01579b' }, ticks: { color: '#01579b' } }
+          }
+        }
+      });
+    }
+
+    function calculate() {
+      const s1 = Math.max(parseFloat(sd1Input.value), 1e-6);
+      const s2 = Math.max(parseFloat(sd2Input.value), 1e-6);
+      const n1 = Math.max(parseInt(n1Input.value, 10), 2);
+      const n2 = Math.max(parseInt(n2Input.value, 10), 2);
+      const ratio = Math.max(parseFloat(ratioInput.value), 1e-6);
+      n1Input.value = n1; n2Input.value = n2; ratioInput.value = ratio;
+      const df1 = n1 - 1;
+      const df2 = n2 - 1;
+      const alpha = parseInt(alphaInput.value, 10) / 100;
+      alphaText.textContent = alpha.toFixed(2);
+      const tail = tailSelect.value;
+      const stat = (s1 * s1) / (s2 * s2 * ratio);
+      const critBounds = critical(alpha, tail, df1, df2);
+      const p = pValue(stat, tail, df1, df2);
+      let reject;
+      if (tail === 'two') {
+        reject = stat <= critBounds.lower || stat >= critBounds.upper;
+      } else if (tail === 'right') {
+        reject = stat >= critBounds.upper;
+      } else {
+        reject = stat <= critBounds.lower;
+      }
+
+      summary.style.display = 'grid';
+      summary.innerHTML = `
+        <strong>ผลการทดสอบ</strong>
+        <span>F = ${stat.toFixed(3)} | df₁ = ${df1}, df₂ = ${df2}</span>
+        <span>Critical bounds: [${critBounds.lower.toFixed(3)}, ${critBounds.upper.toFixed(3)}]</span>
+        <span>p-value ≈ ${p.toFixed(4)}</span>
+        <span>การตัดสินใจ: ${reject ? '<strong style="color:#c62828">ปฏิเสธ H₀</strong>' : '<strong style="color:#2e7d32">ยังไม่ปฏิเสธ H₀</strong>'}</span>
+      `;
+
+      updateChart(stat, critBounds, tail, df1, df2);
+    }
+
+    [sd1Input, sd2Input, n1Input, n2Input, ratioInput, tailSelect].forEach(el => el.addEventListener('input', calculate));
+    alphaInput.addEventListener('input', calculate);
+    calcBtn.addEventListener('click', calculate);
+
+    calculate();
+  </script>
+</body>
+</html>

--- a/prob & Stats/content/31-course-summary.html
+++ b/prob & Stats/content/31-course-summary.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="utf-8" />
+  <title>บทที่ 31: บทสรุปและก้าวต่อไป</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body.page {
+      --accent: #00838f;
+      --accent-light: #4dd0e1;
+      --accent-dark: #006064;
+      --card-bg: rgba(224, 247, 250, 0.94);
+      font-family: "IBM Plex Sans Thai", "Prompt", "Sarabun", system-ui, sans-serif;
+      min-height: 100vh;
+      background: radial-gradient(circle at 15% 18%, rgba(77,208,225,0.26), transparent 60%),
+                  radial-gradient(circle at 80% 18%, rgba(0,96,100,0.2), transparent 60%),
+                  linear-gradient(180deg, rgba(224,247,250,0.92), rgba(236,253,255,0.9));
+    }
+    main.container { max-width: 1100px; margin: 0 auto; padding: clamp(2rem, 5vw, 3.5rem); display: grid; gap: 2.2rem; }
+    header.hero { background: linear-gradient(135deg, var(--accent), var(--accent-light)); color: #fff; padding: clamp(2.6rem, 6vw, 4rem); border-radius: 32px; position: relative; overflow: hidden; box-shadow: 0 32px 54px rgba(0,96,100,0.22); }
+    header.hero::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 78% 18%, rgba(255,255,255,0.4), transparent 55%), radial-gradient(circle at 20% 75%, rgba(255,255,255,0.24), transparent 70%); }
+    header.hero h1 { font-size: clamp(2.4rem, 3vw + 1.5rem, 3.6rem); margin-bottom: 0.75rem; }
+    header.hero p { font-size: 1.12rem; max-width: 720px; line-height: 1.7; }
+    section.card { background: var(--card-bg); border-radius: 26px; padding: clamp(1.8rem, 4vw, 2.6rem); box-shadow: 0 20px 36px rgba(0,96,100,0.14); backdrop-filter: blur(6px); display: grid; gap: 1.1rem; }
+    section.card h2 { color: var(--accent-dark); font-size: 1.9rem; display: flex; align-items: center; gap: 0.75rem; margin: 0; }
+    .roadmap { display: grid; gap: 1rem; }
+    .roadmap article { background: rgba(255,255,255,0.95); border-radius: 18px; padding: 1.1rem 1.3rem; border: 1px solid rgba(0,131,143,0.16); transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .roadmap article.active { transform: translateY(-4px); box-shadow: 0 18px 32px rgba(0,131,143,0.22); border-color: rgba(0,150,136,0.4); }
+    .roadmap article h3 { margin: 0; color: var(--accent-dark); font-size: 1.2rem; }
+    .timeline { display: flex; gap: 0.8rem; align-items: center; }
+    .timeline input { flex: 1; }
+    .badge { background: rgba(0,131,143,0.2); color: var(--accent-dark); padding: 0.2rem 0.85rem; border-radius: 999px; font-size: 0.9rem; font-weight: 600; }
+    .next-steps { display: grid; gap: 1rem; }
+    .next-steps li { background: rgba(255,255,255,0.95); border-radius: 18px; padding: 0.9rem 1.1rem; border: 1px solid rgba(0,131,143,0.14); }
+    .resources { display: grid; gap: 1rem; }
+    .resources a { color: var(--accent-dark); font-weight: 600; text-decoration: none; }
+    .resources a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body class="page">
+  <main class="container">
+    <header class="hero">
+      <span class="badge">สรุปภาพรวม</span>
+      <h1>บทที่ 31: บทสรุป & Next Steps</h1>
+      <p>ทบทวนหัวข้อสำคัญทั้งหมดตั้งแต่หลักการนับ ความน่าจะเป็น ตัวแปรสุ่ม การแจกแจงไม่ต่อเนื่อง/ต่อเนื่อง จนถึงการประมาณค่าและการทดสอบสมมติฐาน พร้อมวางแผนการเรียนรู้ขั้นต่อไป.</p>
+    </header>
+
+    <section class="card">
+      <h2>1. แผนที่การเรียนรู้</h2>
+      <div class="timeline">
+        <label>ความคืบหน้า
+          <input type="range" id="progress" min="1" max="6" value="6" />
+        </label>
+        <span class="note">ขั้นตอน: <span id="progress-text">6 / 6</span></span>
+      </div>
+      <div class="roadmap" id="roadmap">
+        <article data-step="1">
+          <h3>พื้นฐานคณิตศาสตร์สำหรับสถิติ</h3>
+          <p>หลักการนับ, การจัดเรียง/จัดหมู่, การสร้างแซมเปิลสเปซ</p>
+        </article>
+        <article data-step="2">
+          <h3>ความน่าจะเป็นและกฎสำคัญ</h3>
+          <p>ความน่าจะเป็นแบบมีเงื่อนไข, กฎบวก-คูณ, ความเป็นอิสระ</p>
+        </article>
+        <article data-step="3">
+          <h3>ตัวแปรสุ่มและการแจกแจง</h3>
+          <p>PMF/PDF, ค่าคาดหวัง, ความแปรปรวน, การแจกแจงเบื้องต้น</p>
+        </article>
+        <article data-step="4">
+          <h3>การสุ่มตัวอย่างและการประมาณค่า</h3>
+          <p>CLT, ช่วงความเชื่อมั่น, การกำหนดขนาดตัวอย่าง</p>
+        </article>
+        <article data-step="5">
+          <h3>การทดสอบสมมติฐาน</h3>
+          <p>Critical vs p-value, การทดสอบค่าเฉลี่ย/สัดส่วน/ความแปรปรวน</p>
+        </article>
+        <article data-step="6">
+          <h3>สรุปและการประยุกต์</h3>
+          <p>เชื่อมโยงสถิติเชิงอ้างอิงกับการตัดสินใจเชิงข้อมูลจริง</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>2. สิ่งที่คุณทำได้แล้ว</h2>
+      <ul class="next-steps" id="achievement-list">
+        <li>✅ สามารถสร้างช่วงความเชื่อมั่นและตีความได้ถูกต้อง</li>
+        <li>✅ เลือกสถิติทดสอบเหมาะสมตามเงื่อนไข (z, t, χ², F)</li>
+        <li>✅ เข้าใจความหมายของ p-value และพลังการทดสอบ</li>
+        <li>✅ ใช้เครื่องมือเชิงโต้ตอบในการสำรวจข้อมูล</li>
+      </ul>
+    </section>
+
+    <section class="card">
+      <h2>3. เป้าหมายถัดไป</h2>
+      <ul class="next-steps">
+        <li data-priority="1">ศึกษาการทดสอบเชิงพาราเมตริกขั้นสูง เช่น ANOVA, Regression</li>
+        <li data-priority="2">ทดลองใช้ซอฟต์แวร์ (Python/R) เพื่อทำซ้ำเครื่องคิดเลขเหล่านี้</li>
+        <li data-priority="3">ฝึกการสื่อสารผลสถิติด้วยแผนภาพและภาษาที่เข้าใจง่าย</li>
+        <li data-priority="4">เชื่อมโยงกับ Machine Learning เบื้องต้น เช่น Linear Models</li>
+      </ul>
+    </section>
+
+    <section class="card">
+      <h2>4. แหล่งเรียนรู้เพิ่มเติม</h2>
+      <div class="resources">
+        <a href="https://seeing-theory.brown.edu/" target="_blank" rel="noopener">Seeing Theory (Interactive Probability)</a>
+        <a href="https://statquest.org/" target="_blank" rel="noopener">StatQuest – อธิบายแนวคิดสถิติแบบเป็นกันเอง</a>
+        <a href="https://www.khanacademy.org/math/statistics-probability" target="_blank" rel="noopener">Khan Academy Statistics</a>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const progressInput = document.getElementById('progress');
+    const progressText = document.getElementById('progress-text');
+    const roadmap = document.getElementById('roadmap').querySelectorAll('article');
+
+    function updateProgress() {
+      const step = parseInt(progressInput.value, 10);
+      progressText.textContent = `${step} / ${roadmap.length}`;
+      roadmap.forEach(article => {
+        const articleStep = parseInt(article.dataset.step, 10);
+        article.classList.toggle('active', articleStep <= step);
+      });
+    }
+
+    progressInput.addEventListener('input', updateProgress);
+    updateProgress();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add chapters 17–31 with fully styled Thai-language lessons on confidence intervals, sample size, and hypothesis testing topics
- include interactive calculators, chart visualisations, and decision aids for means, proportions, variances, and variance ratios
- provide a course summary page with progress tracker, next steps, and external resources

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da3939635c8331865e41280b168a73