### PR TITLE
Improve probability lessons interactivity and feedback

### DIFF
--- a/prob - Stats/content/03-probability-basics.html
+++ b/prob - Stats/content/03-probability-basics.html
@@ -27,6 +27,9 @@
     .bar { background: linear-gradient(180deg, var(--brand-300), var(--brand-500)); border-radius: var(--radius-lg) var(--radius-lg) 0 0; position: relative; overflow: hidden; }
     .bar span { position: absolute; inset-inline: 0; bottom: -1.75rem; text-align: center; font-size: .875rem; }
     .bar::after { content: attr(data-value); position: absolute; inset-inline: 0; top: .25rem; text-align: center; font-weight: 600; color: white; }
+    .feedback { font-style: italic; color: var(--neutral-600); min-height: 1.5em; }
+    .feedback.error { color: var(--danger-600); }
+    .feedback.success { color: var(--success-600); }
   </style>
 </head>
 <body data-page="lesson">
@@ -138,7 +141,8 @@
           </label>
         </div>
         <button class="primary" id="prob-update">คำนวณความน่าจะเป็น</button>
-        <p>ผลลัพธ์: <strong>P(E) = <span id="prob-result">0.625</span></strong></p>
+        <p id="prob-feedback" class="feedback" aria-live="polite"></p>
+        <p>ผลลัพธ์: <strong>P(E) = <span id="prob-result" aria-live="polite">0.6250</span></strong></p>
         <div class="bar-chart" role="img" aria-label="สัดส่วนของเหตุการณ์">
           <div class="bar" id="bar-fav" style="height:62.5%" data-value="62.5%"><span>สนใจ</span></div>
           <div class="bar" id="bar-unfav" style="height:37.5%" data-value="37.5%"><span>อื่นๆ</span></div>
@@ -165,29 +169,56 @@
       return `${Math.min(100, Math.max(0, value)).toFixed(1)}%`;
     };
 
+    const barFav = document.getElementById('bar-fav');
+    const barUnfav = document.getElementById('bar-unfav');
+    const probResult = document.getElementById('prob-result');
+    const feedbackEl = document.getElementById('prob-feedback');
+    const table = document.getElementById('prob-table');
+
+    const setFeedback = (message = '', type = '') => {
+      feedbackEl.textContent = message;
+      feedbackEl.classList.remove('error', 'success');
+      if (type) feedbackEl.classList.add(type);
+    };
+
+    const setBar = (bar, percent) => {
+      const safePercent = Number.isFinite(percent) && percent > 0 ? percent : 0;
+      const height = clampPercent(safePercent);
+      bar.style.height = height;
+      bar.dataset.value = height;
+    };
+
+    const resetDisplay = (message = '') => {
+      probResult.textContent = '—';
+      setBar(barFav, 0);
+      setBar(barUnfav, 0);
+      setFeedback(message, message ? 'error' : '');
+    };
+
+    const updateDisplay = (probability, announce = true) => {
+      probResult.textContent = probability.toFixed(4);
+      setBar(barFav, probability * 100);
+      setBar(barUnfav, (1 - probability) * 100);
+      setFeedback(announce ? 'บันทึกสถานการณ์ใหม่เรียบร้อยแล้ว!' : '', announce ? 'success' : '');
+    };
+
     document.getElementById('prob-update').addEventListener('click', () => {
       const total = Number(document.getElementById('total-outcomes').value);
       const favor = Number(document.getElementById('favorable-outcomes').value);
       if (!Number.isFinite(total) || total <= 0 || !Number.isFinite(favor) || favor < 0 || favor > total) {
-        document.getElementById('prob-result').textContent = '—';
+        resetDisplay('กรุณากรอกข้อมูลที่ถูกต้อง (n(E) ต้องไม่เกิน n(S))');
         return;
       }
       const probability = favor / total;
-      document.getElementById('prob-result').textContent = probability.toFixed(4);
-      const favPercent = probability * 100;
-      const unfavPercent = 100 - favPercent;
-      const barFav = document.getElementById('bar-fav');
-      const barUnfav = document.getElementById('bar-unfav');
-      barFav.style.height = clampPercent(favPercent);
-      barUnfav.style.height = clampPercent(unfavPercent);
-      barFav.dataset.value = clampPercent(favPercent);
-      barUnfav.dataset.value = clampPercent(unfavPercent);
+      updateDisplay(probability);
 
-      const table = document.getElementById('prob-table');
       const newRow = document.createElement('tr');
       newRow.innerHTML = `<td>สถานการณ์ที่ตั้งเอง</td><td>${total.toLocaleString('th-TH')} ผล</td><td>${favor.toLocaleString('th-TH')} ผล</td><td>${probability.toFixed(4)}</td>`;
       table.prepend(newRow);
     });
+
+    setFeedback('');
+    updateDisplay(5 / 8, false);
   </script>
 </body>
 </html>

--- a/prob - Stats/content/04-conditional.html
+++ b/prob - Stats/content/04-conditional.html
@@ -21,10 +21,12 @@
     .conditional-lab { display: grid; gap: var(--space-3); }
     .conditional-lab input { width: 100%; }
     .venn { display: grid; grid-template-columns: repeat(2, minmax(120px, 1fr)); gap: 1rem; justify-items: center; align-items: center; }
-    .venn div { width: 100%; aspect-ratio: 1 / 1; border-radius: 50%; display: grid; place-items: center; color: white; font-weight: 700; }
+    .venn div { width: 100%; aspect-ratio: 1 / 1; border-radius: 50%; display: grid; place-items: center; color: white; font-weight: 700; text-align: center; gap: .25rem; padding: var(--space-2); }
     .venn .a { background: color-mix(in srgb, var(--brand-500) 80%, transparent); }
     .venn .b { background: color-mix(in srgb, var(--success-500) 80%, transparent); }
     .venn .ab { background: color-mix(in srgb, var(--warning-500) 80%, transparent); grid-column: span 2; width: 60%; aspect-ratio: 1 / 1; }
+    .venn div span.label { font-size: 1rem; font-weight: 700; }
+    .venn div span.value { font-size: .875rem; font-weight: 600; }
     .bar-chart { display: grid; grid-auto-flow: column; gap: var(--space-2); align-items: end; min-height: 160px; padding-block: var(--space-2); }
     .bar { background: linear-gradient(180deg, var(--brand-300), var(--brand-500)); border-radius: var(--radius-lg) var(--radius-lg) 0 0; position: relative; overflow: hidden; }
     .bar span { position: absolute; inset-inline: 0; bottom: -1.75rem; text-align: center; font-size: .875rem; }
@@ -148,18 +150,18 @@
         <button class="primary" id="conditional-update">คำนวณ</button>
         <div class="grid-2">
           <div>
-            <p>P(A) = <strong id="pa">0.4</strong></p>
-            <p>P(B) = <strong id="pb">0.5</strong></p>
-            <p>P(A ∩ B) = <strong id="pab">0.3</strong></p>
-            <p>P(A | B) = <strong id="pa-given-b">0.6</strong></p>
-            <p>P(B | A) = <strong id="pb-given-a">0.75</strong></p>
+            <p>P(A) = <strong id="pa">0.4000</strong></p>
+            <p>P(B) = <strong id="pb">0.5000</strong></p>
+            <p>P(A ∩ B) = <strong id="pab">0.3000</strong></p>
+            <p>P(A | B) = <strong id="pa-given-b">0.6000</strong></p>
+            <p>P(B | A) = <strong id="pb-given-a">0.7500</strong></p>
             <p>Independent? <strong id="independent-flag">ไม่เป็นอิสระ</strong></p>
           </div>
           <div>
             <div class="venn" aria-label="ภาพแทนเซต">
-              <div class="a" id="venn-a">A</div>
-              <div class="b" id="venn-b">B</div>
-              <div class="ab" id="venn-ab">A∩B</div>
+              <div class="a" id="venn-a"><span class="label">A</span><span class="value">40%</span></div>
+              <div class="b" id="venn-b"><span class="label">B</span><span class="value">50%</span></div>
+              <div class="ab" id="venn-ab"><span class="label">A∩B</span><span class="value">30%</span></div>
             </div>
             <div class="bar-chart" role="img" aria-label="เปรียบเทียบความน่าจะเป็น">
               <div class="bar" id="bar-pa" style="height:40%" data-value="40%"><span>P(A)</span></div>
@@ -178,14 +180,39 @@
   <script>
     const percentText = (value) => `${Math.round(value * 1000) / 10}%`;
 
-    document.getElementById('conditional-update').addEventListener('click', () => {
+    const barPa = document.getElementById('bar-pa');
+    const barPb = document.getElementById('bar-pb');
+    const barPab = document.getElementById('bar-pab');
+
+    const setProbabilityValue = (id, probability) => {
+      document.getElementById(id).textContent = Number.isFinite(probability) ? probability.toFixed(4) : '—';
+    };
+
+    const setProbabilityBar = (bar, probability) => {
+      const safe = Number.isFinite(probability) && probability >= 0 ? probability : 0;
+      const display = percentText(safe);
+      bar.style.height = display;
+      bar.dataset.value = display;
+    };
+
+    const setCircle = (id, label, probability) => {
+      const element = document.getElementById(id);
+      const safe = Number.isFinite(probability) && probability >= 0 ? probability : 0;
+      element.innerHTML = `<span class="label">${label}</span><span class="value">${percentText(safe)}</span>`;
+    };
+
+    const render = () => {
       const a = Number(document.getElementById('count-a').value);
       const b = Number(document.getElementById('count-b').value);
       const ab = Number(document.getElementById('count-ab').value);
       const total = Number(document.getElementById('count-total').value);
 
-      if (!Number.isFinite(a) || !Number.isFinite(b) || !Number.isFinite(ab) || !Number.isFinite(total) || total <= 0) return;
-      if (ab > a || ab > b || a > total || b > total || ab > total) return;
+      if (!Number.isFinite(a) || !Number.isFinite(b) || !Number.isFinite(ab) || !Number.isFinite(total) || total <= 0) {
+        return;
+      }
+      if (ab > a || ab > b || a > total || b > total || ab > total) {
+        return;
+      }
 
       const pa = a / total;
       const pb = b / total;
@@ -194,27 +221,25 @@
       const pbGivenA = pa > 0 ? pab / pa : NaN;
       const independent = Math.abs(pab - pa * pb) < 1e-6;
 
-      document.getElementById('pa').textContent = pa.toFixed(4);
-      document.getElementById('pb').textContent = pb.toFixed(4);
-      document.getElementById('pab').textContent = pab.toFixed(4);
-      document.getElementById('pa-given-b').textContent = Number.isFinite(paGivenB) ? paGivenB.toFixed(4) : '—';
-      document.getElementById('pb-given-a').textContent = Number.isFinite(pbGivenA) ? pbGivenA.toFixed(4) : '—';
+      setProbabilityValue('pa', pa);
+      setProbabilityValue('pb', pb);
+      setProbabilityValue('pab', pab);
+      setProbabilityValue('pa-given-b', paGivenB);
+      setProbabilityValue('pb-given-a', pbGivenA);
       document.getElementById('independent-flag').textContent = independent ? 'เป็นอิสระ' : 'ไม่เป็นอิสระ';
 
-      const barPa = document.getElementById('bar-pa');
-      const barPb = document.getElementById('bar-pb');
-      const barPab = document.getElementById('bar-pab');
-      barPa.style.height = percentText(pa);
-      barPb.style.height = percentText(pb);
-      barPab.style.height = percentText(pab);
-      barPa.dataset.value = percentText(pa);
-      barPb.dataset.value = percentText(pb);
-      barPab.dataset.value = percentText(pab);
+      setProbabilityBar(barPa, pa);
+      setProbabilityBar(barPb, pb);
+      setProbabilityBar(barPab, pab);
 
-      document.getElementById('venn-a').textContent = `A\n${percentText(pa)}`.replace('\\n', '\n');
-      document.getElementById('venn-b').textContent = `B\n${percentText(pb)}`.replace('\\n', '\n');
-      document.getElementById('venn-ab').textContent = `A∩B\n${percentText(pab)}`.replace('\\n', '\n');
-    });
+      setCircle('venn-a', 'A', pa);
+      setCircle('venn-b', 'B', pb);
+      setCircle('venn-ab', 'A∩B', pab);
+    };
+
+    document.getElementById('conditional-update').addEventListener('click', render);
+
+    render();
   </script>
 </body>
 </html>

--- a/prob - Stats/content/05-random-variables.html
+++ b/prob - Stats/content/05-random-variables.html
@@ -28,6 +28,9 @@
     .bar span { position: absolute; inset-inline: 0; bottom: -1.75rem; text-align: center; font-size: .875rem; }
     .bar::after { content: attr(data-value); position: absolute; inset-inline: 0; top: .25rem; text-align: center; font-weight: 600; color: white; }
     .note { font-style: italic; color: var(--neutral-600); }
+    .pmf-message { font-style: italic; color: var(--neutral-600); margin-inline-start: .5rem; display: inline-block; min-width: 14ch; }
+    .pmf-message.ok { color: var(--success-600); }
+    .pmf-message.warn { color: var(--danger-600); }
   </style>
 </head>
 <body data-page="lesson">
@@ -149,7 +152,7 @@
 1:0.5
 2:0.25</textarea>
         <button class="primary" id="pmf-update">อัปเดตการแจกแจง</button>
-        <p>ผลรวมความน่าจะเป็น: <strong id="pmf-sum">1.00</strong></p>
+        <p>ผลรวมความน่าจะเป็น: <strong id="pmf-sum">1.0000</strong><span id="pmf-message" class="pmf-message" aria-live="polite"></span></p>
         <div class="bar-chart" id="pmf-chart" role="img" aria-label="กราฟแท่งความน่าจะเป็น"></div>
       </div>
     </section>
@@ -161,35 +164,78 @@
   <script>
     const chart = document.getElementById('pmf-chart');
     const sumEl = document.getElementById('pmf-sum');
+    const messageEl = document.getElementById('pmf-message');
 
-    const renderPMF = (pairs) => {
+    const setMessage = (text = '', type = '') => {
+      messageEl.textContent = text;
+      messageEl.classList.remove('ok', 'warn');
+      if (type) messageEl.classList.add(type);
+    };
+
+    const renderPMF = ({ pairs, invalid }) => {
       chart.innerHTML = '';
-      const validPairs = pairs.filter(({ prob }) => prob >= 0);
-      const total = validPairs.reduce((acc, { prob }) => acc + prob, 0);
+      const total = pairs.reduce((acc, { prob }) => acc + prob, 0);
       sumEl.textContent = total.toFixed(4);
-      const maxProb = Math.max(...validPairs.map(({ prob }) => prob), 0.01);
-      validPairs.forEach(({ value, prob }) => {
+
+      if (!pairs.length) {
+        const note = document.createElement('p');
+        note.className = 'note';
+        note.textContent = invalid ? `ไม่มีข้อมูลที่จะแสดง (ละเว้น ${invalid} บรรทัดที่ไม่ถูกต้อง)` : 'ไม่มีข้อมูลที่จะแสดง';
+        chart.appendChild(note);
+        setMessage('เพิ่มข้อมูลในรูปแบบ x:prob ต่อบรรทัดเพื่อดูกราฟ', 'warn');
+        return;
+      }
+
+      const maxProb = Math.max(...pairs.map(({ prob }) => prob), 0.01);
+      pairs.forEach(({ value, prob }) => {
         const bar = document.createElement('div');
         bar.className = 'bar';
         bar.style.height = `${Math.min(100, (prob / maxProb) * 100)}%`;
         bar.dataset.value = prob.toFixed(3);
+        bar.title = `P(X=${value}) = ${prob.toFixed(3)}`;
         const label = document.createElement('span');
         label.textContent = value;
         bar.appendChild(label);
         chart.appendChild(bar);
       });
+
+      const tolerance = 1e-4;
+      if (Math.abs(total - 1) <= tolerance) {
+        const message = invalid ? `ผลรวม ≈ 1 (ละเว้น ${invalid} บรรทัดที่ไม่ถูกต้อง)` : 'ข้อมูลสมบูรณ์ (ผลรวม ≈ 1)';
+        setMessage(message, 'ok');
+      } else {
+        const message = invalid ? `ผลรวม = ${total.toFixed(4)} (ละเว้น ${invalid} บรรทัดที่ไม่ถูกต้อง)` : `ผลรวม = ${total.toFixed(4)} (ควรเท่ากับ 1)`;
+        setMessage(message, 'warn');
+      }
     };
 
     const parseInput = (text) => {
-      return text.split(/\n+/).map(line => line.trim()).filter(Boolean).map(line => {
-        const [value, prob] = line.split(':');
-        return { value: value.trim(), prob: Number(prob) };
-      }).filter(({ prob }) => Number.isFinite(prob));
+      const pairs = [];
+      let invalid = 0;
+      text.split(/\n+/).forEach((line, index) => {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          return;
+        }
+        const [rawValue, rawProb] = trimmed.split(':');
+        if (rawProb === undefined) {
+          invalid += 1;
+          return;
+        }
+        const value = (rawValue ?? '').trim() || `ค่า ${index + 1}`;
+        const prob = Number(rawProb);
+        if (!Number.isFinite(prob) || prob < 0) {
+          invalid += 1;
+          return;
+        }
+        pairs.push({ value, prob });
+      });
+      return { pairs, invalid };
     };
 
     document.getElementById('pmf-update').addEventListener('click', () => {
-      const pairs = parseInput(document.getElementById('pmf-input').value);
-      renderPMF(pairs);
+      const data = parseInput(document.getElementById('pmf-input').value);
+      renderPMF(data);
     });
 
     renderPMF(parseInput(document.getElementById('pmf-input').value));


### PR DESCRIPTION
## Summary
- add inline guidance, validation, and dynamic result resets to the probability basics lab
- restyle the conditional probability explorer venn view and shareable helpers for updating metrics
- upgrade the random variable playground parser with invalid-input handling, user messaging, and accessible status output

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc81892be083318d742bccff67896e