### PR TITLE
Add practice quizzes to probability lessons

### DIFF
--- a/prob - Stats/content/02-descriptive.html
+++ b/prob - Stats/content/02-descriptive.html
@@ -28,6 +28,11 @@
     .example-table th, .example-table td { border: 1px solid var(--neutral-300); padding: .5rem .75rem; text-align: center; }
     .example-table th { background: var(--neutral-100); }
     .code-block { font-family: var(--font-mono); background: var(--neutral-950); color: var(--neutral-0); border-radius: var(--radius-lg); padding: var(--space-3); overflow-x: auto; }
+    .quiz-card { background: var(--neutral-100); border: 1px solid var(--neutral-200); border-radius: var(--radius-lg); padding: var(--space-3); display: grid; gap: var(--space-3); }
+    .quiz-grid { display: grid; gap: var(--space-2); grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+    .quiz-grid label { display: grid; gap: var(--space-1); font-weight: 600; }
+    .quiz-grid input { width: 100%; }
+    .quiz-feedback { font-weight: 600; }
   </style>
 </head>
 <body data-page="lesson">
@@ -134,6 +139,28 @@
     </section>
 
     <section>
+      <h2>Mini Quiz: ทดสอบความเข้าใจ</h2>
+      <p>ลองคำนวณและกรอกคำตอบลงในช่องเพื่อทบทวนความเข้าใจของกฎการนับ Permutation และ Combination</p>
+      <div class="quiz-card">
+        <div class="quiz-grid">
+          <label for="quiz-add">กฎการคูณ: เสื้อ 3 แบบ × กางเกง 4 แบบ มีได้กี่ชุด?
+            <input id="quiz-add" type="number" min="0" inputmode="numeric" placeholder="กรอกจำนวนวิธี">
+          </label>
+
+          <label for="quiz-perm">Permutation: P(5, 2) = ?
+            <input id="quiz-perm" type="number" min="0" inputmode="numeric" placeholder="กรอกค่า P(5,2)">
+          </label>
+
+          <label for="quiz-comb">Combination: C(6, 2) = ?
+            <input id="quiz-comb" type="number" min="0" inputmode="numeric" placeholder="กรอกค่า C(6,2)">
+          </label>
+        </div>
+        <button class="primary" id="quiz-check">ตรวจคำตอบ</button>
+        <p id="quiz-feedback" class="quiz-feedback" aria-live="polite">พร้อมตรวจคำตอบ!</p>
+      </div>
+    </section>
+
+    <section>
       <h2>Interactive: Counting Playground</h2>
       <p>ทดลองปรับจำนวนชิ้นและขั้นตอนเพื่อดูผลลัพธ์ของกฎการบวก กฎการคูณ รวมถึง Permutation และ Combination แบบโต้ตอบ</p>
       <div class="grid-2">
@@ -221,6 +248,46 @@
       document.getElementById('comb-result').textContent = isFinite(combination) ? combination.toLocaleString('th-TH') : '—';
 
       updateBars([addition, multiplication, permutation, combination]);
+    });
+
+    const quizItems = [
+      {
+        id: 'quiz-add',
+        answer: 12,
+        success: 'ยอดเยี่ยม! คุณเข้าใจกฎการคูณของหลักการนับอย่างถูกต้อง',
+        retry: 'ลองคิดว่าต้องเลือกเสื้อและกางเกงต่อเนื่องกันอีกครั้งนะครับ'
+      },
+      {
+        id: 'quiz-perm',
+        answer: factorial(5) / factorial(5 - 2),
+        success: 'ตรงเป๊ะ! P(5,2) = 20 สะท้อนความสำคัญของลำดับ',
+        retry: 'Permutation ให้ความสำคัญกับลำดับ ลองใช้สูตร n!/(n-r)! ดูใหม่อีกครั้ง'
+      },
+      {
+        id: 'quiz-comb',
+        answer: (factorial(6) / factorial(6 - 2)) / factorial(2),
+        success: 'ถูกต้องเลย! C(6,2) = 15 เพราะไม่สนใจลำดับ',
+        retry: 'ลองนำค่า P(6,2) มาหารด้วย 2! เพื่อปรับกรณีที่สลับตำแหน่งซ้ำกันออกครับ'
+      }
+    ];
+
+    document.getElementById('quiz-check').addEventListener('click', () => {
+      let hasEmpty = false;
+      const feedback = quizItems.map(({ id, answer, success, retry }) => {
+        const field = document.getElementById(id);
+        const raw = field.value;
+        if (raw.trim() === '') {
+          hasEmpty = true;
+          field.focus();
+        }
+        const value = Number(raw);
+        if (!Number.isFinite(value)) {
+          hasEmpty = true;
+        }
+        return Math.abs(value - answer) < 1e-6 ? success : retry;
+      });
+      const message = hasEmpty ? 'กรุณากรอกตัวเลขให้ครบทุกข้อก่อนครับ' : feedback.join(' • ');
+      document.getElementById('quiz-feedback').textContent = message;
     });
 
     updateBars([7, 12, 336, 56]);

--- a/prob - Stats/content/03-probability-basics.html
+++ b/prob - Stats/content/03-probability-basics.html
@@ -27,6 +27,10 @@
     .bar { background: linear-gradient(180deg, var(--brand-300), var(--brand-500)); border-radius: var(--radius-lg) var(--radius-lg) 0 0; position: relative; overflow: hidden; }
     .bar span { position: absolute; inset-inline: 0; bottom: -1.75rem; text-align: center; font-size: .875rem; }
     .bar::after { content: attr(data-value); position: absolute; inset-inline: 0; top: .25rem; text-align: center; font-weight: 600; color: white; }
+    .practice-card { background: var(--neutral-100); border: 1px solid var(--neutral-200); border-radius: var(--radius-lg); padding: var(--space-3); display: grid; gap: var(--space-3); }
+    .practice-grid { display: grid; gap: var(--space-2); grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+    .practice-grid label { display: grid; gap: var(--space-1); font-weight: 600; }
+    .practice-feedback { font-weight: 600; }
   </style>
 </head>
 <body data-page="lesson">
@@ -126,6 +130,23 @@
     </section>
 
     <section>
+      <h2>Self-Practice: Complement &amp; Odds</h2>
+      <p>กำหนดจำนวนผลลัพธ์ที่สนใจและไม่สนใจเพื่อคำนวณ P(E), P(E<sup>c</sup>) และอัตราต่อรอง (Odds)</p>
+      <div class="practice-card">
+        <div class="practice-grid">
+          <label for="practice-total">จำนวนผลลัพธ์ทั้งหมด (n(S))
+            <input id="practice-total" type="number" min="1" value="10">
+          </label>
+          <label for="practice-fav">ผลลัพธ์ที่สนใจ (n(E))
+            <input id="practice-fav" type="number" min="0" value="4">
+          </label>
+        </div>
+        <button class="primary" id="practice-run">คำนวณ</button>
+        <p id="practice-feedback" class="practice-feedback" aria-live="polite">ลองกรอกค่าที่ต้องการแล้วกดคำนวณได้เลยครับ</p>
+      </div>
+    </section>
+
+    <section>
       <h2>Interactive: Probability Lab</h2>
       <p>ตั้งค่าจำนวนผลลัพธ์ทั้งหมดและผลลัพธ์ที่สนใจเพื่อดูความน่าจะเป็นพร้อมกราฟสัดส่วน</p>
       <div class="prob-lab">
@@ -187,6 +208,21 @@
       const newRow = document.createElement('tr');
       newRow.innerHTML = `<td>สถานการณ์ที่ตั้งเอง</td><td>${total.toLocaleString('th-TH')} ผล</td><td>${favor.toLocaleString('th-TH')} ผล</td><td>${probability.toFixed(4)}</td>`;
       table.prepend(newRow);
+    });
+
+    document.getElementById('practice-run').addEventListener('click', () => {
+      const total = Number(document.getElementById('practice-total').value);
+      const favor = Number(document.getElementById('practice-fav').value);
+      const feedbackEl = document.getElementById('practice-feedback');
+      if (!Number.isFinite(total) || total <= 0 || !Number.isFinite(favor) || favor < 0 || favor > total) {
+        feedbackEl.textContent = 'กรุณากรอกค่าที่ถูกต้อง (n(E) ต้องอยู่ระหว่าง 0 และ n(S))';
+        return;
+      }
+      const probability = favor / total;
+      const complement = 1 - probability;
+      const odds = complement > 1e-8 ? probability / complement : Infinity;
+      const oddsText = Number.isFinite(odds) ? odds.toFixed(4) : '∞';
+      feedbackEl.textContent = `P(E) = ${probability.toFixed(4)}, P(E^c) = ${complement.toFixed(4)}, Odds(E) = ${oddsText}:1`;
     });
   </script>
 </body>

--- a/prob - Stats/content/04-conditional.html
+++ b/prob - Stats/content/04-conditional.html
@@ -154,6 +154,7 @@
             <p>P(A | B) = <strong id="pa-given-b">0.6</strong></p>
             <p>P(B | A) = <strong id="pb-given-a">0.75</strong></p>
             <p>Independent? <strong id="independent-flag">ไม่เป็นอิสระ</strong></p>
+            <p>Mutually Exclusive? <strong id="exclusive-flag">ไม่ใช่</strong></p>
           </div>
           <div>
             <div class="venn" aria-label="ภาพแทนเซต">
@@ -193,6 +194,7 @@
       const paGivenB = pb > 0 ? pab / pb : NaN;
       const pbGivenA = pa > 0 ? pab / pa : NaN;
       const independent = Math.abs(pab - pa * pb) < 1e-6;
+      const exclusive = Math.abs(pab) < 1e-6;
 
       document.getElementById('pa').textContent = pa.toFixed(4);
       document.getElementById('pb').textContent = pb.toFixed(4);
@@ -200,6 +202,7 @@
       document.getElementById('pa-given-b').textContent = Number.isFinite(paGivenB) ? paGivenB.toFixed(4) : '—';
       document.getElementById('pb-given-a').textContent = Number.isFinite(pbGivenA) ? pbGivenA.toFixed(4) : '—';
       document.getElementById('independent-flag').textContent = independent ? 'เป็นอิสระ' : 'ไม่เป็นอิสระ';
+      document.getElementById('exclusive-flag').textContent = exclusive ? 'ใช่' : 'ไม่ใช่';
 
       const barPa = document.getElementById('bar-pa');
       const barPb = document.getElementById('bar-pb');

--- a/prob - Stats/content/05-random-variables.html
+++ b/prob - Stats/content/05-random-variables.html
@@ -150,6 +150,7 @@
 2:0.25</textarea>
         <button class="primary" id="pmf-update">อัปเดตการแจกแจง</button>
         <p>ผลรวมความน่าจะเป็น: <strong id="pmf-sum">1.00</strong></p>
+        <p>ค่าคาดหมาย E[X]: <strong id="pmf-expected">1.0000</strong></p>
         <div class="bar-chart" id="pmf-chart" role="img" aria-label="กราฟแท่งความน่าจะเป็น"></div>
       </div>
     </section>
@@ -161,12 +162,20 @@
   <script>
     const chart = document.getElementById('pmf-chart');
     const sumEl = document.getElementById('pmf-sum');
+    const expectedEl = document.getElementById('pmf-expected');
 
     const renderPMF = (pairs) => {
       chart.innerHTML = '';
       const validPairs = pairs.filter(({ prob }) => prob >= 0);
       const total = validPairs.reduce((acc, { prob }) => acc + prob, 0);
       sumEl.textContent = total.toFixed(4);
+      const numericPairs = validPairs.filter(({ value }) => !Number.isNaN(Number(value)));
+      if (numericPairs.length) {
+        const expected = numericPairs.reduce((acc, { value, prob }) => acc + Number(value) * prob, 0);
+        expectedEl.textContent = expected.toFixed(4);
+      } else {
+        expectedEl.textContent = '—';
+      }
       const maxProb = Math.max(...validPairs.map(({ prob }) => prob), 0.01);
       validPairs.forEach(({ value, prob }) => {
         const bar = document.createElement('div');


### PR DESCRIPTION
## Summary
- add a mini counting quiz with automated feedback to the counting principles lesson
- introduce a complement and odds practice card for the probability basics lesson
- display mutual exclusivity diagnostics in the conditional probability explorer
- calculate and surface the expected value from PMF inputs in the random variables playground

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc8812462c8331b38f9ed076eaab9d